### PR TITLE
refactor: allow static file paths to be set via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you do not wish to use the default, you must set the environment variable `UT
 #### SeqRepo
 `cool-seq-tool` relies on [seqrepo](https://github.com/biocommons/biocommons.seqrepo), which you must download yourself.
 
+Use the `SEQREPO_DATA_PATH` environment variable to set the path of an already existing SeqRepo directory. The default is `/usr/local/share/seqrepo/latest`.
+
 From the _root_ directory:
 ```
 pip install seqrepo
@@ -96,13 +98,15 @@ exit
 
 ![image](biomart.png)
 
+Use the `TRANSCRIPT_MAPPINGS_PATH` environment variable to set the path of an already existing `transcript_mappings.tsv`. The default is `cool_seq_tool/data/transcript_mapping.tsv`.
+
 #### LRG_RefSeqGene
 
-`cool-seq-tool` fetches the latest version of `LRG_RefSeqGene`. This file is found can be found [here](https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene).
+`cool-seq-tool` fetches the latest version of `LRG_RefSeqGene` if the environment variable `LRG_REFSEQGENE_PATH` is not set. When `LRG_REFSEQGENE_PATH` is set, `cool-seq-tool` will look at this path and expect the LRG_RefSeqGene file. This file is found can be found [here](https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene).
 
 #### MANE Summary Data
 
-`cool-seq-tool` fetches the latest version of `MANE.GRCh38.*.summary.txt.gz`. This file is found can be found [here](https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/current/).
+`cool-seq-tool` fetches the latest version of `MANE.GRCh38.*.summary.txt.gz` if the environment variable `MANE_SUMMARY_PATH` is not set. When `MANE_SUMMARY_PATH` is set, `cool-seq-tool` will look at this path and expect the MANE Summary Data file. This file is found can be found [here](https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/current/).
 
 ## Starting the UTA Tools Service Locally
 

--- a/cool_seq_tool/__init__.py
+++ b/cool_seq_tool/__init__.py
@@ -14,21 +14,27 @@ logger.setLevel(logging.DEBUG)
 
 LOG_FN = "cool_seq_tool.log"
 
-if "UTA_DB_URL" in environ:
-    UTA_DB_URL = environ["UTA_DB_URL"]
-else:
-    UTA_DB_URL = "postgresql://uta_admin@localhost:5433/uta/uta_20210129"
+UTA_DB_URL = environ.get("UTA_DB_URL",
+                         "postgresql://uta_admin@localhost:5433/uta/uta_20210129")
+SEQREPO_DATA_PATH = Path(environ.get("SEQREPO_DATA_PATH",
+                                     "/usr/local/share/seqrepo/latest"))
+TRANSCRIPT_MAPPINGS_PATH = Path(environ.get("TRANSCRIPT_MAPPINGS_PATH",
+                                            f"{APP_ROOT}/data/transcript_mapping.tsv"))
 
-if "SEQREPO_DATA_PATH" in environ:
-    SEQREPO_DATA_PATH = environ["SEQREPO_DATA_PATH"]
-else:
-    SEQREPO_DATA_PATH = "/usr/local/share/seqrepo/latest"
 
-TRANSCRIPT_MAPPINGS_PATH = f"{APP_ROOT}/data/transcript_mapping.tsv"
+MANE_SUMMARY_PATH = environ.get("MANE_SUMMARY_PATH")
+LRG_REFSEQGENE_PATH = environ.get("LRG_REFSEQGENE_PATH")
+if not all((MANE_SUMMARY_PATH, LRG_REFSEQGENE_PATH)):
+    from cool_seq_tool.data import DataDownload  # noqa: E402, I202
+    d = DataDownload()
 
-from cool_seq_tool.data import DataDownload  # noqa: E402, I202
-d = DataDownload()
-MANE_SUMMARY_PATH = d._mane_summary_path
-LRG_REFSEQGENE_PATH = d._lrg_refseqgene_path
+    if not MANE_SUMMARY_PATH:
+        MANE_SUMMARY_PATH = d._mane_summary_path
+
+    if not LRG_REFSEQGENE_PATH:
+        LRG_REFSEQGENE_PATH = d._lrg_refseqgene_path
+MANE_SUMMARY_PATH = Path(MANE_SUMMARY_PATH)
+LRG_REFSEQGENE_PATH = Path(LRG_REFSEQGENE_PATH)
+
 
 from cool_seq_tool.cool_seq_tool import CoolSeqTool  # noqa: E402, F401, I202

--- a/cool_seq_tool/cool_seq_tool.py
+++ b/cool_seq_tool/cool_seq_tool.py
@@ -21,20 +21,20 @@ class CoolSeqTool:
     """Class to initialize data sources."""
 
     def __init__(
-        self, seqrepo_data_path: str = SEQREPO_DATA_PATH,
-        transcript_file_path: str = TRANSCRIPT_MAPPINGS_PATH,
-        lrg_refseqgene_path: str = LRG_REFSEQGENE_PATH,
-        mane_data_path: str = MANE_SUMMARY_PATH,
+        self, seqrepo_data_path: Path = SEQREPO_DATA_PATH,
+        transcript_file_path: Path = TRANSCRIPT_MAPPINGS_PATH,
+        lrg_refseqgene_path: Path = LRG_REFSEQGENE_PATH,
+        mane_data_path: Path = MANE_SUMMARY_PATH,
         db_url: str = UTA_DB_URL, db_pwd: str = "",
         gene_query_handler: GeneQueryHandler = None,
         gene_db_url: str = "", gene_db_region: str = "us-east-2"
     ) -> None:
         """Initialize CoolSeqTool class
 
-        :param str seqrepo_data_path: The path to the seqrepo directory.
-        :param str transcript_file_path: The path to transcript_mappings.tsv
-        :param str lrg_refseqgene_path: The path to LRG_RefSeqGene
-        :param str mane_data_path: Path to RefSeq MANE summary data
+        :param Path seqrepo_data_path: The path to the seqrepo directory.
+        :param Path transcript_file_path: The path to transcript_mappings.tsv
+        :param Path lrg_refseqgene_path: The path to LRG_RefSeqGene
+        :param Path mane_data_path: Path to RefSeq MANE summary data
         :param str db_url: PostgreSQL connection URL
             Format: `driver://user:pass@host/database/schema`
         :param str db_pwd: User's password for uta database

--- a/cool_seq_tool/data_sources/mane_transcript_mappings.py
+++ b/cool_seq_tool/data_sources/mane_transcript_mappings.py
@@ -1,4 +1,5 @@
 """The module for loading MANE Transcript mappings to genes."""
+from pathlib import Path
 from typing import Dict, Optional, List
 
 import pandas as pd
@@ -9,9 +10,9 @@ from cool_seq_tool import MANE_SUMMARY_PATH, logger
 class MANETranscriptMappings:
     """The MANE Transcript mappings class."""
 
-    def __init__(self, mane_data_path: str = MANE_SUMMARY_PATH) -> None:
+    def __init__(self, mane_data_path: Path = MANE_SUMMARY_PATH) -> None:
         """Initialize the MANE Transcript mappings class.
-        :param str mane_data_path: Path to RefSeq MANE summary data
+        :param Path mane_data_path: Path to RefSeq MANE summary data
         """
         self.mane_data_path = mane_data_path
         self.df = self._load_mane_transcript_data()

--- a/cool_seq_tool/data_sources/seqrepo_access.py
+++ b/cool_seq_tool/data_sources/seqrepo_access.py
@@ -1,6 +1,7 @@
 """A module for accessing SeqRepo."""
 from typing import Optional, List, Tuple, Union
 from os import environ
+from pathlib import Path
 
 from biocommons.seqrepo import SeqRepo
 
@@ -12,9 +13,9 @@ from cool_seq_tool.data_sources.residue_mode import get_inter_residue_pos
 class SeqRepoAccess:
     """The SeqRepoAccess class."""
 
-    def __init__(self, seqrepo_data_path: str = SEQREPO_DATA_PATH) -> None:
+    def __init__(self, seqrepo_data_path: Path = SEQREPO_DATA_PATH) -> None:
         """Initialize the SeqRepoAccess class.
-        :param str seqrepo_data_path: The path to the seqrepo directory.
+        :param Path seqrepo_data_path: The path to the seqrepo directory.
         """
         environ["SEQREPO_LRU_CACHE_MAXSIZE"] = "none"
         self.seqrepo_client = SeqRepo(seqrepo_data_path)

--- a/cool_seq_tool/data_sources/transcript_mappings.py
+++ b/cool_seq_tool/data_sources/transcript_mappings.py
@@ -1,5 +1,6 @@
 """The module for Transcript Mappings."""
 import csv
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from cool_seq_tool import TRANSCRIPT_MAPPINGS_PATH, LRG_REFSEQGENE_PATH
@@ -8,12 +9,12 @@ from cool_seq_tool import TRANSCRIPT_MAPPINGS_PATH, LRG_REFSEQGENE_PATH
 class TranscriptMappings:
     """The transcript mappings class."""
 
-    def __init__(self, transcript_file_path: str = TRANSCRIPT_MAPPINGS_PATH,
-                 lrg_refseqgene_path: str = LRG_REFSEQGENE_PATH) -> None:
+    def __init__(self, transcript_file_path: Path = TRANSCRIPT_MAPPINGS_PATH,
+                 lrg_refseqgene_path: Path = LRG_REFSEQGENE_PATH) -> None:
         """Initialize the transcript mappings class.
 
-        :param str transcript_file_path: Path to transcript mappings file
-        :param str lrg_refseqgene_path: Path to LRG RefSeqGene file
+        :param Path transcript_file_path: Path to transcript mappings file
+        :param Path lrg_refseqgene_path: Path to LRG RefSeqGene file
         """
         # ENSP <-> Gene Symbol
         self.ensembl_protein_version_for_gene_symbol: Dict[str, List[str]] = {}
@@ -51,11 +52,10 @@ class TranscriptMappings:
         self._load_transcript_mappings_data(transcript_file_path)
         self._load_refseq_gene_symbol_data(lrg_refseqgene_path)
 
-    def _load_transcript_mappings_data(self,
-                                       transcript_file_path: str) -> None:
+    def _load_transcript_mappings_data(self, transcript_file_path: Path) -> None:
         """Load transcript mappings file to dictionaries.
 
-        :param str transcript_file_path: Path to transcript mappings file
+        :param Path transcript_file_path: Path to transcript mappings file
         """
         with open(transcript_file_path) as file:
             reader = csv.DictReader(file, delimiter="\t")
@@ -96,10 +96,10 @@ class TranscriptMappings:
                         self.ensp_to_enst[versioned_protein_transcript] = \
                             versioned_transcript
 
-    def _load_refseq_gene_symbol_data(self, lrg_refseqgene_path: str) -> None:
+    def _load_refseq_gene_symbol_data(self, lrg_refseqgene_path: Path) -> None:
         """Load data from RefSeq Gene Symbol file to dictionaries.
 
-        :param str lrg_refseqgene_path: Path to LRG RefSeqGene file
+        :param Path lrg_refseqgene_path: Path to LRG RefSeqGene file
         """
         with open(lrg_refseqgene_path) as file:
             reader = csv.DictReader(file, delimiter="\t")


### PR DESCRIPTION
Close #131 

Notes:
- SEQREPO_DATA_PATH, TRANSCRIPT_MAPPINGS_PATH, MANE_SUMMARY_PATH, and LRG_REFSEQGENE_PATH paths can now be set using env vars
- Updates type hints / docstrings for these to be Path rather than string