### PR TITLE
feat!: remove separate UTA password param

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you have trouble installing UTA, you can visit [these two READMEs](https://gi
 
 To connect to the UTA database, you can use the default url (`postgresql://uta_admin:uta@localhost:5433/uta/uta_20210129`).
 
-If you do not wish to use the default, you must set the environment variable `UTA_DB_URL` which has the format of `driver://user:pass@host:port/database/schema`.
+If you do not wish to use the default, you must set the environment variable `UTA_DB_URL` which has the format of `driver://user:password@host:port/database/schema`.
 
 ### Data Downloads
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you have trouble installing UTA, you can visit [these two READMEs](https://gi
 
 #### Connecting to the database
 
-To connect to the UTA database, you can use the default url (`postgresql://uta_admin@localhost:5433/uta/uta_20210129`). If you use the default url, you must either set the password using environment variable `UTA_PASSWORD` or setting the parameter `db_pwd` in the UTA class.
+To connect to the UTA database, you can use the default url (`postgresql://uta_admin:uta@localhost:5433/uta/uta_20210129`).
 
 If you do not wish to use the default, you must set the environment variable `UTA_DB_URL` which has the format of `driver://user:pass@host:port/database/schema`.
 

--- a/cool_seq_tool/app.py
+++ b/cool_seq_tool/app.py
@@ -39,7 +39,7 @@ class CoolSeqTool:
         :param Path lrg_refseqgene_path: The path to LRG_RefSeqGene
         :param Path mane_data_path: Path to RefSeq MANE summary data
         :param str db_url: PostgreSQL connection URL
-            Format: `driver://user:pass@host/database/schema`
+            Format: `driver://user:password@host/database/schema`
         :param Optional[GeneQueryHandler] gene_query_handler: Gene normalizer query
             handler instance. If this is provided, will use a current instance. If this
             is not provided, will create a new instance.

--- a/cool_seq_tool/app.py
+++ b/cool_seq_tool/app.py
@@ -29,8 +29,7 @@ class CoolSeqTool:
         transcript_file_path: Path = TRANSCRIPT_MAPPINGS_PATH,
         lrg_refseqgene_path: Path = LRG_REFSEQGENE_PATH,
         mane_data_path: Path = MANE_SUMMARY_PATH,
-        db_url: str = UTA_DB_URL, db_pwd: str = "",
-        gene_query_handler: Optional[GeneQueryHandler] = None,
+        db_url: str = UTA_DB_URL, gene_query_handler: Optional[GeneQueryHandler] = None,
         gene_db_url: str = "", gene_db_region: str = "us-east-2",
         sr: Optional[SeqRepo] = None
     ) -> None:
@@ -41,7 +40,6 @@ class CoolSeqTool:
         :param Path mane_data_path: Path to RefSeq MANE summary data
         :param str db_url: PostgreSQL connection URL
             Format: `driver://user:pass@host/database/schema`
-        :param str db_pwd: User's password for uta database
         :param Optional[GeneQueryHandler] gene_query_handler: Gene normalizer query
             handler instance. If this is provided, will use a current instance. If this
             is not provided, will create a new instance.
@@ -60,7 +58,7 @@ class CoolSeqTool:
             lrg_refseqgene_path=lrg_refseqgene_path)
         self.mane_transcript_mappings = MANETranscriptMappings(
             mane_data_path=mane_data_path)
-        self.uta_db = UTADatabase(db_url=db_url, db_pwd=db_pwd)
+        self.uta_db = UTADatabase(db_url=db_url)
         gene_normalizer = GeneNormalizer(gene_query_handler, gene_db_url,
                                          gene_db_region)
         self.gene_query_handler = gene_normalizer.query_handler

--- a/cool_seq_tool/data_sources/uta_database.py
+++ b/cool_seq_tool/data_sources/uta_database.py
@@ -44,7 +44,7 @@ class UTADatabase:
         method to construct a new instance: await UTADatabase.create()
 
         :param db_url: PostgreSQL connection URL
-            Format: `driver://user:pass@host/database/schema`
+            Format: `driver://user:password@host/database/schema`
         :param chain_file_37_to_38: Optional path to chain file for 37 to 38 assembly.
             This is used for pyliftover. If this is not provided, will check to see if
             LIFTOVER_CHAIN_37_TO_38 env var is set. If neither is provided, will allow
@@ -128,7 +128,7 @@ class UTADatabase:
         """Provide fully-initialized class instance (a la factory pattern)
         :param UTADatabaseType cls: supplied implicitly
         :param str db_url: PostgreSQL connection URL
-            Format: `driver://user:pass@host/database/schema`
+            Format: `driver://user:password@host/database/schema`
         :return: UTA DB access class instance
         """
         self = cls(db_url)


### PR DESCRIPTION
Users should set the postgres password in the connection URL, rather than via a separate env var or method param. Now `uta_database.py` is only 1152 lines long!