### PR TITLE
docs: add README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 CoolSeqTool
 </h1>
 
-**[Documentation](#)** · [Installation](#) · [Usage](#) · [API reference](#)
+**[Documentation](https://coolseqtool.readthedocs.io/en/latest/)** · [Installation](https://coolseqtool.readthedocs.io/en/latest/install.html) · [Usage](https://coolseqtool.readthedocs.io/en/latest/usage.html) · [API reference](https://coolseqtool.readthedocs.io/en/latest/reference/index.html)
 
 ## Overview
 
@@ -49,4 +49,4 @@ All CoolSeqTool resources can be initialized by way of a top-level class instanc
 
 ## Feedback and contributing
 
-We welcome bug reports, feature requests, and code contributions from users and interested collaborators. The [documentation](#) contains guidance for submitting feedback and contributing new code.
+We welcome bug reports, feature requests, and code contributions from users and interested collaborators. The [documentation](https://coolseqtool.readthedocs.io/en/latest/contributing.html) contains guidance for submitting feedback and contributing new code.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ CoolSeqTool is available on [PyPI](https://pypi.org/project/cool-seq-tool)
 python3 -m pip install cool-seq-tool
 ```
 
-See the [installation instructions](#) in the documentation for a description of dependency setup requirements.
+See the [installation instructions](https://coolseqtool.readthedocs.io/en/latest/install.html) in the documentation for a description of dependency setup requirements.
 
 ---
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,15 @@
 [metadata]
 name = cool_seq_tool
-description = Common Operations On Lots of Sequences Tool
+description = "Common Operations On Lots of Sequences Tool"
 long_description = file:README.md
 long_description_content_type = text/markdown
 author = Wagner Lab, Nationwide Childrens Hospital
-home_page = https://github.com/GenomicMedLab/cool-seq-tool
+home_page = "https://github.com/GenomicMedLab/cool-seq-tool"
+project_urls =
+    Documentation = "https://coolseqtool.readthedocs.io/en/latest/index.html"
+    Changelog = "https://github.com/genomicmedlab/cool-seq-tool/releases"
+    Source = "https://github.com/genomicmedlab/cool-seq-tool"
+    Tracker = "https://github.com/genomicmedlab/cool-seq-tool/issues"
 license = MIT
 
 [options]


### PR DESCRIPTION
Wasn't entirely sure what the URL would end up being until it built, so adding these now that the other docs PR is merged