### PR TITLE
fix: StrEnum to Enum for python < 3.11

### DIFF
--- a/src/cool_seq_tool/mappers/mane_transcript.py
+++ b/src/cool_seq_tool/mappers/mane_transcript.py
@@ -13,7 +13,7 @@ constraints and data models for coordinate representation.
 """
 import logging
 import math
-from enum import StrEnum
+from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import polars as pl
@@ -37,7 +37,7 @@ from cool_seq_tool.utils import get_inter_residue_pos
 logger = logging.getLogger(__name__)
 
 
-class EndAnnotationLayer(StrEnum):
+class EndAnnotationLayer(str, Enum):
     """Define constraints for end annotation layer. This is used for determining the
     end annotation layer when getting the longest compatible remaining representation
     """

--- a/src/cool_seq_tool/version.py
+++ b/src/cool_seq_tool/version.py
@@ -1,2 +1,2 @@
 """Define package version."""
-__version__ = "0.4.0-dev1"
+__version__ = "0.4.0-dev2"


### PR DESCRIPTION
@jsstevenson PR noticed this since there are CI tests for python >= 3.8