### PR TITLE
docs: add generated changelog

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,6 +38,8 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    env:
+      SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.SPHINX_GITHUB_CHANGELOG_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,7 @@
+Changelog
+---------
+
+.. changelog::
+    :changelog-url: https://coolseqtool.readthedocs.io/en/stable/#changelog
+    :github: https://github.com/genomicmedlab/cool-seq-tool/releases/
+    :pypi: https://pypi.org/project/cool-seq-tool/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx.ext.autosummary",
     "sphinx_copybutton",
+    "sphinx_github_changelog",
 ]
 
 templates_path = ["_templates"]
@@ -78,3 +79,8 @@ def linkcode_resolve(domain, info):
 # -- code block style --------------------------------------------------------
 pygments_style = "default"
 pygements_dark_style = "monokai"
+
+# -- changelog ---------------------------------------------------------------
+# import os
+#
+# sphinx_github_changelog_token = os.environ.get("GENOMICMEDLAB_GH_DOCS_API_TOKEN", "failed -- make sure to set API token")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,4 +20,5 @@ CoolSeqTool was created to support the `Knowledgebase Integration Project <https
     Transcript Selection<transcript_selection>
     API Reference<reference/index>
     Contributing<contributing>
+    Changelog<changelog>
     License<license>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
     "sphinx-copybutton==0.5.2",
     "sphinxext-opengraph==0.8.2",
     "furo==2023.3.27",
+    "sphinx-github-changelog==1.2.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
https://coolseqtool--259.org.readthedocs.build/en/259/changelog.html

was thinking about the VRS-Python changelog, did some googling, decided to test it out here. You need to generate a GitHub API access token but if the repo in question is public, it needs 0 permissions (you leave everything unchecked) (unfortunately it will expire after like a year or something).