### PR TITLE
docs: fix residue mode illustration rendering

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,8 +79,3 @@ def linkcode_resolve(domain, info):
 # -- code block style --------------------------------------------------------
 pygments_style = "default"
 pygements_dark_style = "monokai"
-
-# -- changelog ---------------------------------------------------------------
-# import os
-#
-# sphinx_github_changelog_token = os.environ.get("GENOMICMEDLAB_GH_DOCS_API_TOKEN", "failed -- make sure to set API token")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,3 +79,25 @@ def linkcode_resolve(domain, info):
 # -- code block style --------------------------------------------------------
 pygments_style = "default"
 pygements_dark_style = "monokai"
+
+# -- preprocess docstrings ---------------------------------------------------
+from typing import List
+from types import ModuleType
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import Options
+
+
+def _clip_rst_tables(app: Sphinx, what: str, name: str, obj: ModuleType, options: Options, lines: List[str]):
+    """The ResidueMode docstring contains an RST table and an ASCII table because
+    the former gets omitted in IDEs like VSCode and the latter won't render properly in
+    Sphinx docs. This chops out the ASCII table when rendering autodocs.
+    """
+    if what == "class" and name == "cool_seq_tool.schemas.ResidueMode":
+        for i in range(len(lines) -1, -1, -1):
+            line = lines[i]
+            if line.count("|") >= 8:
+                del lines[i]
+        print("Running preprocessing on ResidueMode docstring...")
+
+def setup(app: Sphinx):
+    app.connect("autodoc-process-docstring", _clip_rst_tables)

--- a/src/cool_seq_tool/schemas.py
+++ b/src/cool_seq_tool/schemas.py
@@ -56,6 +56,11 @@ class ResidueMode(str, Enum):
     careful to define the coordinate mode of their data when calling ``cool-seq-tool``
     functions.
 
+                      |   | C |   | T |   | G |   |
+    ZERO              |   | 0 |   | 1 |   | 2 |   |
+    RESIDUE           |   | 1 |   | 2 |   | 3 |   |
+    INTER_RESIDUE     | 0 |   | 1 |   | 2 |   | 3 |
+
     .. tabularcolumns:: |L|C|C|C|C|C|C|C|
     .. list-table::
        :header-rows: 1

--- a/src/cool_seq_tool/schemas.py
+++ b/src/cool_seq_tool/schemas.py
@@ -52,10 +52,50 @@ class TranscriptPriority(str, Enum):
 class ResidueMode(str, Enum):
     """Create Enum for residue modes.
 
-                      |   | C |   | T |   | G |   |
-    ZERO              |   | 0 |   | 1 |   | 2 |   |
-    RESIDUE           |   | 1 |   | 2 |   | 3 |   |
-    INTER_RESIDUE     | 0 |   | 1 |   | 2 |   | 3 |
+    We typically prefer to operate in inter-residue coordinates, but users should be
+    careful to define the coordinate mode of their data when calling ``cool-seq-tool``
+    functions.
+
+    .. tabularcolumns:: |L|C|C|C|C|C|C|C|
+    .. list-table::
+       :header-rows: 1
+
+       * -
+         -
+         - C
+         -
+         - T
+         -
+         - G
+         -
+       * - ``ZERO``
+         -
+         - 0
+         -
+         - 1
+         -
+         - 2
+         -
+       * - ``RESIDUE``
+         -
+         - 1
+         -
+         - 2
+         -
+         - 3
+         -
+       * - ``INTER_RESIDUE``
+         - 0
+         -
+         - 1
+         -
+         - 2
+         -
+         - 3
+
+
+    See "Conventions that promote reliable data sharing" and figure 3 within the
+    `Variation Representation Schema (VRS) paper <https://www.ncbi.nlm.nih.gov/pmc/articles/pmid/35311178/>`_ for further discussion.
     """
 
     ZERO = "zero"


### PR DESCRIPTION
The existing lil ASCII table in the ResidueMode docstring wouldn't render properly in Sphinx nor in markdown-style blocks (eg in VSCode popups). This adds an RST table and retains the ASCII table but puts it in a code block, and then strips the ASCII table out when constructing the Sphinx autodoc page.

Broken:

<img width="837" alt="Screenshot 2024-03-21 at 10 11 14 AM" src="https://github.com/GenomicMedLab/cool-seq-tool/assets/12942397/a6c4e44d-626f-4aca-9d65-3f6b4bcac0d5">

Fixed in VSCode (it auto ignores all of the RST stuff):

<img width="493" alt="Screenshot 2024-03-21 at 10 12 32 AM" src="https://github.com/GenomicMedLab/cool-seq-tool/assets/12942397/922da000-6f21-4b18-b5dd-14e3f516ece0">

Fixed in Sphinx docs:

<img width="818" alt="Screenshot 2024-03-21 at 10 11 33 AM" src="https://github.com/GenomicMedLab/cool-seq-tool/assets/12942397/224217d6-dfe1-4ef5-9526-439439be8e06">

