### PR TITLE
feat: enable suppression of latest resource check

### DIFF
--- a/src/cool_seq_tool/app.py
+++ b/src/cool_seq_tool/app.py
@@ -49,6 +49,7 @@ class CoolSeqTool:
         mane_data_path: Path | None = None,
         db_url: str = UTA_DB_URL,
         sr: Optional[SeqRepo] = None,
+        force_local_files: bool = False,
     ) -> None:
         """Initialize CoolSeqTool class
 
@@ -58,6 +59,8 @@ class CoolSeqTool:
         :param db_url: PostgreSQL connection URL
             Format: ``driver://user:password@host/database/schema``
         :param sr: SeqRepo instance. If this is not provided, will create a new instance
+        :param force_local_files: if ``True``, don't check for or try to acquire latest
+            versions of static data files -- just use most recently available, if any
         """
         if not sr:
             sr = SeqRepo(root_dir=SEQREPO_ROOT_DIR)
@@ -65,9 +68,10 @@ class CoolSeqTool:
         self.transcript_mappings = TranscriptMappings(
             transcript_file_path=transcript_file_path,
             lrg_refseqgene_path=lrg_refseqgene_path,
+            from_local=force_local_files,
         )
         self.mane_transcript_mappings = ManeTranscriptMappings(
-            mane_data_path=mane_data_path
+            mane_data_path=mane_data_path, from_local=force_local_files
         )
         self.uta_db = UtaDatabase(db_url=db_url)
         self.alignment_mapper = AlignmentMapper(

--- a/src/cool_seq_tool/sources/mane_transcript_mappings.py
+++ b/src/cool_seq_tool/sources/mane_transcript_mappings.py
@@ -28,7 +28,6 @@ class ManeTranscriptMappings:
         """Initialize the MANE Transcript mappings class.
 
         :param mane_data_path: Path to RefSeq MANE summary data
-        :param use_local_data: if `True`,
         :param from_local: if ``True``, don't check for or acquire latest version --
             just provide most recent locally available file, if possible, and raise
             error otherwise

--- a/src/cool_seq_tool/sources/mane_transcript_mappings.py
+++ b/src/cool_seq_tool/sources/mane_transcript_mappings.py
@@ -22,13 +22,19 @@ class ManeTranscriptMappings:
     See the `NCBI MANE page <https://www.ncbi.nlm.nih.gov/refseq/MANE/>`_ for more information.
     """
 
-    def __init__(self, mane_data_path: Path | None = None) -> None:
+    def __init__(
+        self, mane_data_path: Path | None = None, from_local: bool = False
+    ) -> None:
         """Initialize the MANE Transcript mappings class.
 
-        :param Path mane_data_path: Path to RefSeq MANE summary data
+        :param mane_data_path: Path to RefSeq MANE summary data
+        :param use_local_data: if `True`,
+        :param from_local: if ``True``, don't check for or acquire latest version --
+            just provide most recent locally available file, if possible, and raise
+            error otherwise
         """
         if not mane_data_path:
-            mane_data_path = get_data_file(DataFile.MANE_SUMMARY)
+            mane_data_path = get_data_file(DataFile.MANE_SUMMARY, from_local)
         self.mane_data_path = mane_data_path
         self.df = self._load_mane_transcript_data()
 

--- a/src/cool_seq_tool/sources/transcript_mappings.py
+++ b/src/cool_seq_tool/sources/transcript_mappings.py
@@ -23,11 +23,15 @@ class TranscriptMappings:
         self,
         transcript_file_path: Path | None = None,
         lrg_refseqgene_path: Path | None = None,
+        from_local: bool = False,
     ) -> None:
         """Initialize the transcript mappings class.
 
         :param transcript_file_path: Path to transcript mappings file
         :param lrg_refseqgene_path: Path to LRG RefSeqGene file
+        :param from_local: if ``True``, don't check for or acquire latest version --
+            just provide most recent locally available file, if possible, and raise
+            error otherwise
         """
         # ENSP <-> Gene Symbol
         self.ensembl_protein_version_for_gene_symbol: Dict[str, List[str]] = {}
@@ -58,10 +62,11 @@ class TranscriptMappings:
         self.ensp_to_enst: Dict[str, str] = {}
 
         self._load_transcript_mappings_data(
-            transcript_file_path or get_data_file(DataFile.TRANSCRIPT_MAPPINGS)
+            transcript_file_path
+            or get_data_file(DataFile.TRANSCRIPT_MAPPINGS, from_local)
         )
         self._load_refseq_gene_symbol_data(
-            lrg_refseqgene_path or get_data_file(DataFile.LRG_REFSEQGENE)
+            lrg_refseqgene_path or get_data_file(DataFile.LRG_REFSEQGENE, from_local)
         )
 
     def _load_transcript_mappings_data(self, transcript_file_path: Path) -> None:


### PR DESCRIPTION
* Optionally, suppress checks for static files being up-to-date, and instead just go with the latest available data file. IE, pass a value to the wags-tails `from_local` param.

Making this a separate PR to merge into the resource acquisition branch just because it's a thought that I had kind of late.