### PR TITLE
feat: consistently handle bare and prefixed chromosome numbering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "uvicorn",
     "fastapi",
     "ga4gh.vrs",
-    "wags-tails ~= 0.1.3"
+    "wags-tails ~= 0.1.3",
+    "bioutils",
 ]
 dynamic = ["version"]
 

--- a/src/cool_seq_tool/handlers/seqrepo_access.py
+++ b/src/cool_seq_tool/handlers/seqrepo_access.py
@@ -143,7 +143,7 @@ class SeqRepoAccess(SeqRepoDataProxy):
         :return: Accessions for chromosome (ordered by latest assembly)
         """
         acs = []
-        for assembly in ["GRCh38", "GRCh37"]:
+        for assembly in Assembly.__members__:
             tmp_acs, _ = self.translate_identifier(
                 f"{assembly}:{process_chromosome_input(chromosome)}",
                 target_namespaces="refseq",

--- a/src/cool_seq_tool/handlers/seqrepo_access.py
+++ b/src/cool_seq_tool/handlers/seqrepo_access.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 
 from cool_seq_tool.schemas import ResidueMode
-from cool_seq_tool.utils import get_inter_residue_pos
+from cool_seq_tool.utils import get_inter_residue_pos, process_chromosome_input
 
 _logger = logging.getLogger(__name__)
 
@@ -145,12 +145,16 @@ class SeqRepoAccess(SeqRepoDataProxy):
         acs = []
         for assembly in ["GRCh38", "GRCh37"]:
             tmp_acs, _ = self.translate_identifier(
-                f"{assembly}:chr{chromosome}", target_namespaces="refseq"
+                f"{assembly}:{process_chromosome_input(chromosome)}",
+                target_namespaces="refseq",
             )
             acs += [ac.split("refseq:")[-1] for ac in tmp_acs]
         if acs:
             return acs, None
-        return None, f"{chromosome} is not a valid chromosome"
+        return (
+            None,
+            f'Unable to find matching accessions for "{chromosome}" in SeqRepo.',
+        )
 
     def ac_to_chromosome(self, ac: str) -> tuple[str | None, str | None]:
         """Get chromosome for accession.

--- a/src/cool_seq_tool/handlers/seqrepo_access.py
+++ b/src/cool_seq_tool/handlers/seqrepo_access.py
@@ -143,7 +143,7 @@ class SeqRepoAccess(SeqRepoDataProxy):
         :return: Accessions for chromosome (ordered by latest assembly)
         """
         acs = []
-        for assembly in Assembly.__members__:
+        for assembly in ["GRCh38", "GRCh37"]:
             tmp_acs, _ = self.translate_identifier(
                 f"{assembly}:{process_chromosome_input(chromosome)}",
                 target_namespaces="refseq",

--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -259,9 +259,8 @@ class ExonGenomicCoordsMapper:
         >>> result.genomic_data.exon_start, result.genomic_data.exon_end
         (1, 8)
 
-        :param chromosome: Chromosome. Must give chromosome without a prefix
-            (i.e. ``1`` or ``X``). If not provided, must provide ``alt_ac``.
-            If ``alt_ac`` is also provided, ``alt_ac`` will be used.
+        :param chromosome: e.g. ``"1"`` or ``"chr1"``. If not provided, must provide
+            ``alt_ac``. If ``alt_ac`` is also provided, ``alt_ac`` will be used.
         :param alt_ac: Genomic accession (i.e. ``NC_000001.11``). If not provided,
             must provide ``chromosome. If ``chromosome`` is also provided, ``alt_ac``
             will be used.

--- a/tests/handlers/test_seqrepo_access.py
+++ b/tests/handlers/test_seqrepo_access.py
@@ -118,6 +118,9 @@ def test_chromosome_to_acs(test_seqrepo_access):
     resp = test_seqrepo_access.chromosome_to_acs("7")
     assert resp == (["NC_000007.14", "NC_000007.13"], None)
 
+    resp = test_seqrepo_access.chromosome_to_acs("chr7")
+    assert resp == (["NC_000007.14", "NC_000007.13"], None)
+
     resp = test_seqrepo_access.chromosome_to_acs("X")
     assert resp == (["NC_000023.11", "NC_000023.10"], None)
 
@@ -125,7 +128,7 @@ def test_chromosome_to_acs(test_seqrepo_access):
     assert resp == (["NC_000024.10", "NC_000024.9"], None)
 
     resp = test_seqrepo_access.chromosome_to_acs("117")
-    assert resp == (None, "117 is not a valid chromosome")
+    assert resp == (None, 'Unable to find matching accessions for "117" in SeqRepo.')
 
 
 def test_ac_to_chromosome(test_seqrepo_access):

--- a/tests/mappers/test_exon_genomic_coords.py
+++ b/tests/mappers/test_exon_genomic_coords.py
@@ -427,6 +427,16 @@ async def test_genomic_to_transcript_fusion_context(
     genomic_data_assertion_checks(resp, zbtb10_exon3_end)
 
     inputs = {
+        "chromosome": "chr8",
+        "end": 80514010,
+        "strand": Strand.POSITIVE,
+        "gene": "ZBTB10",
+        "get_nearest_transcript_junction": True,
+    }
+    resp = await test_egc_mapper.genomic_to_transcript_exon_coordinates(**inputs)
+    genomic_data_assertion_checks(resp, zbtb10_exon3_end)
+
+    inputs = {
         "chromosome": "8",
         "start": 80518581,
         "strand": Strand.POSITIVE,

--- a/tests/sources/test_uta_database.py
+++ b/tests/sources/test_uta_database.py
@@ -4,7 +4,7 @@ import copy
 
 import pytest
 
-from cool_seq_tool.schemas import Strand
+from cool_seq_tool.schemas import Assembly, Strand
 
 
 @pytest.fixture(scope="module")
@@ -329,14 +329,12 @@ async def test_liftover_to_38(test_db, genomic_tx_data):
 
 def test_get_liftover(test_db):
     """Test that get_liftover works correctly."""
-    resp = test_db.get_liftover("chr7", 140453136, "GRCh38")
+    resp = test_db.get_liftover("chr7", 140453136, Assembly.GRCH38)
+    assert resp == ("chr7", 140753336)
+    resp = test_db.get_liftover("7", 140453136, Assembly.GRCH38)
     assert resp == ("chr7", 140753336)
 
-    resp = test_db.get_liftover("chr17", 140453136, "GRCh38")
-    assert resp is None
-
-    # not prefixed w chr
-    resp = test_db.get_liftover("7", 140453136, "GRCh38")
+    resp = test_db.get_liftover("chr17", 140453136, Assembly.GRCH38)
     assert resp is None
 
 


### PR DESCRIPTION
* Use common processing methods for all cases of chromosome args that transforms bare number strings like `"7"` into UCSC-style prefixed strings like `"chr7"`. 
* Fills in some vagueries surrounding chromosome/accession usage in documentation