### PR TITLE
refactor!: move liftover to separate module

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -55,6 +55,7 @@ Data Mappers
 
    cool_seq_tool.mappers.alignment
    cool_seq_tool.mappers.exon_genomic_coords
+   cool_seq_tool.mappers.liftover
    cool_seq_tool.mappers.mane_transcript
 
 Resources

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -82,9 +82,9 @@ Individual classes will accept arguments upon initialization to set parameters r
    * - ``UTA_DB_URL``
      - A `libpq connection string <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_, i.e. of the form ``postgresql://<user>:<password>@<host>:<port>/<database>/<schema>``, used by the :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>` class. By default, it is set to ``postgresql://uta_admin:uta@localhost:5432/uta/uta_20210129b``.
    * - ``LIFTOVER_CHAIN_37_TO_38``
-     - A path to a `chainfile <https://genome.ucsc.edu/goldenPath/help/chain.html>`_ for lifting from GRCh37 to GRCh38. Used by the :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>` class as input to `agct <https://pypi.org/project/agct/>`_. If not provided, agct will fetch it automatically from UCSC.
+     - A path to a `chainfile <https://genome.ucsc.edu/goldenPath/help/chain.html>`_ for lifting from GRCh37 to GRCh38. Used by the :py:class:`LiftOver <cool_seq_tool.mappers.liftover.LiftOver>` class as input to `agct <https://pypi.org/project/agct/>`_. If not provided, agct will fetch it automatically from UCSC.
    * - ``LIFTOVER_CHAIN_38_TO_37``
-     - A path to a `chainfile <https://genome.ucsc.edu/goldenPath/help/chain.html>`_ for lifting from GRCh38 to GRCh37. Used by the :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>` class as input to `agct <https://pypi.org/project/agct/>`_. If not provided, agct will fetch it automatically from UCSC.
+     - A path to a `chainfile <https://genome.ucsc.edu/goldenPath/help/chain.html>`_ for lifting from GRCh38 to GRCh37. Used by the :py:class:`LiftOver <cool_seq_tool.mappers.liftover.LiftOver>` class as input to `agct <https://pypi.org/project/agct/>`_. If not provided, agct will fetch it automatically from UCSC.
 
 Schema support
 --------------

--- a/src/cool_seq_tool/app.py
+++ b/src/cool_seq_tool/app.py
@@ -30,6 +30,7 @@ class CoolSeqTool:
     * ``self.mane_transcript_mappings``: :py:class:`ManeTranscriptMappings <cool_seq_tool.sources.mane_transcript_mappings.ManeTranscriptMappings>`
     * ``self.uta_db``: :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>`
     * ``self.alignment_mapper``: :py:class:`AlignmentMapper <cool_seq_tool.mappers.alignment.AlignmentMapper>`
+    * ``self.liftover``: :py:class:`LiftOver <cool_seq_tool.mappers.liftover.LiftOver>`
     * ``self.mane_transcript``: :py:class:`ManeTranscript <cool_seq_tool.mappers.mane_transcript.ManeTranscript>`
     * ``self.ex_g_coords_mapper``: :py:class:`ExonGenomicCoordsMapper <cool_seq_tool.mappers.exon_genomic_coords.ExonGenomicCoordsMapper>`
     """

--- a/src/cool_seq_tool/app.py
+++ b/src/cool_seq_tool/app.py
@@ -11,6 +11,7 @@ from cool_seq_tool.handlers.seqrepo_access import SEQREPO_ROOT_DIR, SeqRepoAcces
 from cool_seq_tool.mappers import (
     AlignmentMapper,
     ExonGenomicCoordsMapper,
+    LiftOver,
     ManeTranscript,
 )
 from cool_seq_tool.sources.mane_transcript_mappings import ManeTranscriptMappings
@@ -94,15 +95,18 @@ class CoolSeqTool:
         self.alignment_mapper = AlignmentMapper(
             self.seqrepo_access, self.transcript_mappings, self.uta_db
         )
+        self.liftover = LiftOver()
         self.mane_transcript = ManeTranscript(
             self.seqrepo_access,
             self.transcript_mappings,
             self.mane_transcript_mappings,
             self.uta_db,
+            self.liftover,
         )
         self.ex_g_coords_mapper = ExonGenomicCoordsMapper(
             self.seqrepo_access,
             self.uta_db,
             self.mane_transcript,
             self.mane_transcript_mappings,
+            self.liftover,
         )

--- a/src/cool_seq_tool/mappers/__init__.py
+++ b/src/cool_seq_tool/mappers/__init__.py
@@ -1,8 +1,9 @@
 """Module for mapping data"""
 
 from .alignment import AlignmentMapper  # noqa: I001
+from .liftover import LiftOver
 from .mane_transcript import ManeTranscript
 from .exon_genomic_coords import ExonGenomicCoordsMapper
 
 
-__all__ = ["AlignmentMapper", "ManeTranscript", "ExonGenomicCoordsMapper"]
+__all__ = ["AlignmentMapper", "LiftOver", "ManeTranscript", "ExonGenomicCoordsMapper"]

--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -4,6 +4,7 @@ import logging
 from typing import Literal, TypeVar
 
 from cool_seq_tool.handlers.seqrepo_access import SeqRepoAccess
+from cool_seq_tool.mappers.liftover import LiftOver
 from cool_seq_tool.mappers.mane_transcript import CdnaRepresentation, ManeTranscript
 from cool_seq_tool.schemas import (
     AnnotationLayer,
@@ -37,6 +38,7 @@ class ExonGenomicCoordsMapper:
         uta_db: UtaDatabase,
         mane_transcript: ManeTranscript,
         mane_transcript_mappings: ManeTranscriptMappings,
+        liftover: LiftOver,
     ) -> None:
         """Initialize ExonGenomicCoordsMapper class.
 
@@ -63,11 +65,13 @@ class ExonGenomicCoordsMapper:
         :param uta_db: UtaDatabase instance to give access to query UTA database
         :param mane_transcript: Instance to align to MANE or compatible representation
         :param mane_transcript_mappings: Instance to provide access to ManeTranscriptMappings class
+        :param liftover: Instance to provide mapping between human genome assemblies
         """
         self.seqrepo_access = seqrepo_access
         self.uta_db = uta_db
         self.mane_transcript = mane_transcript
         self.mane_transcript_mappings = mane_transcript_mappings
+        self.liftover = liftover
 
     @staticmethod
     def _return_warnings(
@@ -804,7 +808,7 @@ class ExonGenomicCoordsMapper:
                 return f"Unable to get chromosome and assembly for " f"{params['chr']}"
 
             chromosome_number, assembly = descr
-            liftover_data = self.uta_db.get_liftover(
+            liftover_data = self.liftover.get_liftover(
                 chromosome_number, params["pos"], Assembly.GRCH38
             )
             if liftover_data is None:

--- a/src/cool_seq_tool/mappers/liftover.py
+++ b/src/cool_seq_tool/mappers/liftover.py
@@ -1,0 +1,90 @@
+"""Module for mapping to/from human genome assemblies.
+
+Currently only supports GRCh37 <-> GRCh38
+"""
+
+import logging
+from os import environ
+
+from agct import Converter, Genome
+
+from cool_seq_tool.schemas import Assembly
+from cool_seq_tool.utils import process_chromosome_input
+
+# Environment variables for paths to chain files for agct
+LIFTOVER_CHAIN_37_TO_38 = environ.get("LIFTOVER_CHAIN_37_TO_38")
+LIFTOVER_CHAIN_38_TO_37 = environ.get("LIFTOVER_CHAIN_38_TO_37")
+
+
+_logger = logging.getLogger(__name__)
+
+
+class LiftOver:
+    """Class for mapping to/from human genome assemblies
+
+    Currently only supports GRCh37 <-> GRCh38
+    """
+
+    def __init__(
+        self,
+        chain_file_37_to_38: str | None = None,
+        chain_file_38_to_37: str | None = None,
+    ) -> None:
+        """Initialize liftover class
+
+        :param chain_file_37_to_38: Optional path to chain file for 37 to 38 assembly.
+            This is used for ``agct``. If this is not provided, will check to see
+            if ``LIFTOVER_CHAIN_37_TO_38`` env var is set. If neither is provided, will
+            allow ``agct`` to download a chain file from UCSC
+        :param chain_file_38_to_37: Optional path to chain file for 38 to 37 assembly.
+            This is used for ``agct``. If this is not provided, will check to see
+            if ``LIFTOVER_CHAIN_38_TO_37`` env var is set. If neither is provided, will
+            allow ``agct`` to download a chain file from UCSC
+        """
+        self.from_37_to_38 = Converter(
+            chainfile=chain_file_37_to_38 or LIFTOVER_CHAIN_37_TO_38,
+            from_db=Genome.HG19,
+            to_db=Genome.HG38,
+        )
+        self.from_38_to_37 = Converter(
+            chainfile=chain_file_38_to_37 or LIFTOVER_CHAIN_38_TO_37,
+            from_db=Genome.HG38,
+            to_db=Genome.HG19,
+        )
+
+    def get_liftover(
+        self, chromosome: str, pos: int, liftover_to_assembly: Assembly
+    ) -> tuple[str, int] | None:
+        """Get new genome assembly data for a position on a chromosome.
+
+        Use a UCSC-style chromosome name:
+
+        >>> from cool_seq_tool.mappers import LiftOver
+        >>> from cool_seq_tool.schemas import Assembly
+        >>> lo = LiftOver()
+        >>> lo.get_liftover("chr7", 140453136, Assembly.GRCH38)
+        ('chr7', 140753336)
+
+        Chromosome names can also be NCBI-style, without prefixes:
+
+        >>> lo.get_liftover("7", 140453136, Assembly.GRCH38)
+        ('chr7', 140753336)
+
+        :param chromosome: The chromosome number, e.g. ``"chr7"``, ``"chrX"``, ``"5"``.
+        :param pos: Position on the chromosome
+        :param liftover_to_assembly: Assembly to liftover to
+        :return: Target chromosome and target position for assembly
+        """
+        chromosome = process_chromosome_input(chromosome, "LiftOver.get_liftover()")
+        if liftover_to_assembly == Assembly.GRCH38:
+            liftover = self.from_37_to_38.convert_coordinate(chromosome, pos)
+        elif liftover_to_assembly == Assembly.GRCH37:
+            liftover = self.from_38_to_37.convert_coordinate(chromosome, pos)
+        else:
+            _logger.warning("%s assembly not supported", liftover_to_assembly)
+            liftover = None
+
+        if not liftover:
+            _logger.warning("%s does not exist on %s", pos, chromosome)
+            return None
+        return liftover[0][:2]

--- a/src/cool_seq_tool/resources/status.py
+++ b/src/cool_seq_tool/resources/status.py
@@ -9,8 +9,9 @@ from asyncpg import InvalidCatalogNameError, UndefinedTableError
 from biocommons.seqrepo import SeqRepo
 
 from cool_seq_tool.handlers.seqrepo_access import SEQREPO_ROOT_DIR, SeqRepoAccess
+from cool_seq_tool.mappers.liftover import LiftOver
 from cool_seq_tool.resources.data_files import DataFile, get_data_file
-from cool_seq_tool.sources.uta_database import UTA_DB_URL, UtaDatabase, get_liftover
+from cool_seq_tool.sources.uta_database import UTA_DB_URL, UtaDatabase
 
 _logger = logging.getLogger(__name__)
 
@@ -42,9 +43,7 @@ async def check_status(
     Arguments are intended to mirror arguments to :py:meth:`cool_seq_tool.app.CoolSeqTool.__init__`.
 
     Additional arguments are available for testing paths to specific chainfiles (same
-    signature as :py:meth:`cool_seq_tool.sources.uta_database.UtaDatabase.__init__`).
-    Note that chainfile failures also entail UTA initialization failure; this status is
-    reported separately to enable more precise debugging.
+    signature as :py:meth:`cool_seq_tool.mappers.liftover.LiftOver.__init__`).
 
     >>> from cool_seq_tool.resources.status import check_status
     >>> await check_status()
@@ -104,7 +103,10 @@ async def check_status(
             status[name_lower] = True
 
     try:
-        get_liftover(chain_file_37_to_38, chain_file_38_to_37)
+        LiftOver(
+            chain_file_37_to_38=chain_file_37_to_38,
+            chain_file_38_to_37=chain_file_38_to_37,
+        )
     except (FileNotFoundError, ChainfileError) as e:
         _logger.error("agct converter setup failed: %s", e)
     except Exception as e:

--- a/src/cool_seq_tool/sources/uta_database.py
+++ b/src/cool_seq_tool/sources/uta_database.py
@@ -11,56 +11,19 @@ from urllib.parse import quote, unquote, urlparse
 import asyncpg
 import boto3
 import polars as pl
-from agct import Converter, Genome
 from asyncpg.exceptions import InterfaceError, InvalidAuthorizationSpecificationError
 from botocore.exceptions import ClientError
 
 from cool_seq_tool.schemas import AnnotationLayer, Assembly, Strand
-from cool_seq_tool.utils import process_chromosome_input
 
 # use `bound` to upper-bound UtaDatabase or child classes
 UTADatabaseType = TypeVar("UTADatabaseType", bound="UtaDatabase")
-
-# Environment variables for paths to chain files for agct
-LIFTOVER_CHAIN_37_TO_38 = environ.get("LIFTOVER_CHAIN_37_TO_38")
-LIFTOVER_CHAIN_38_TO_37 = environ.get("LIFTOVER_CHAIN_38_TO_37")
 
 UTA_DB_URL = environ.get(
     "UTA_DB_URL", "postgresql://uta_admin:uta@localhost:5432/uta/uta_20210129b"
 )
 
 _logger = logging.getLogger(__name__)
-
-
-def get_liftover(
-    chain_file_37_to_38: str | None = None, chain_file_38_to_37: str | None = None
-) -> tuple[Converter, Converter]:
-    """Fetch Converter instances between GRCh37 and 38.
-
-    Factored out of the UTA Database initialization method to support less expensive
-    status check-type operations.
-
-    :param chain_file_37_to_38: Optional path to chain file for 37 to 38 assembly.
-        This is used for ``agct``. If this is not provided, will check to see
-        if ``LIFTOVER_CHAIN_37_TO_38`` env var is set. If neither is provided, will
-        allow ``agct`` to download a chain file from UCSC
-    :param chain_file_38_to_37: Optional path to chain file for 38 to 37 assembly.
-        This is used for ``agct``. If this is not provided, will check to see
-        if ``LIFTOVER_CHAIN_38_TO_37`` env var is set. If neither is provided, will
-        allow ``agct`` to download a chain file from UCSC
-    :return: converters (37->38, 38->37)
-    """
-    chain_file_37_to_38 = chain_file_37_to_38 or LIFTOVER_CHAIN_37_TO_38
-    if chain_file_37_to_38:
-        converter_37_to_38 = Converter(chainfile=chain_file_37_to_38)
-    else:
-        converter_37_to_38 = Converter(from_db=Genome.HG19, to_db=Genome.HG38)
-    chain_file_38_to_37 = chain_file_38_to_37 or LIFTOVER_CHAIN_38_TO_37
-    if chain_file_38_to_37:
-        converter_38_to_37 = Converter(chainfile=chain_file_38_to_37)
-    else:
-        converter_38_to_37 = Converter(from_db=Genome.HG38, to_db=Genome.HG19)
-    return (converter_37_to_38, converter_38_to_37)
 
 
 class UtaDatabase:
@@ -76,34 +39,18 @@ class UtaDatabase:
     >>> uta_db = asyncio.run(UtaDatabase.create())
     """
 
-    def __init__(
-        self,
-        db_url: str = UTA_DB_URL,
-        chain_file_37_to_38: str | None = None,
-        chain_file_38_to_37: str | None = None,
-    ) -> None:
+    def __init__(self, db_url: str = UTA_DB_URL) -> None:
         """Initialize DB class. Should only be used by ``create()`` method, and not
         be called directly by a user.
 
         :param db_url: PostgreSQL connection URL
             Format: ``driver://user:password@host/database/schema``
-        :param chain_file_37_to_38: Optional path to chain file for 37 to 38 assembly.
-            This is used for ``agct``. If this is not provided, will check to see
-            if ``LIFTOVER_CHAIN_37_TO_38`` env var is set. If neither is provided, will
-            allow ``agct`` to download a chain file from UCSC
-        :param chain_file_38_to_37: Optional path to chain file for 38 to 37 assembly.
-            This is used for ``agct``. If this is not provided, will check to see
-            if ``LIFTOVER_CHAIN_38_TO_37`` env var is set. If neither is provided, will
-            allow ``agct`` to download a chain file from UCSC
         """
         self.schema = None
         self._connection_pool = None
         original_pwd = db_url.split("//")[-1].split("@")[0].split(":")[-1]
         self.db_url = db_url.replace(original_pwd, quote(original_pwd))
         self.args = self._get_conn_args()
-        self.liftover_37_to_38, self.liftover_38_to_37 = get_liftover(
-            chain_file_37_to_38, chain_file_38_to_37
-        )
 
     def _get_conn_args(self) -> dict:
         """Return connection arguments.
@@ -959,137 +906,6 @@ class UtaDatabase:
             return None
 
         return chromosome, assembly
-
-    async def liftover_to_38(self, genomic_tx_data: dict) -> None:
-        """Liftover genomic_tx_data to hg38 assembly.
-
-        :param genomic_tx_data: Dictionary containing gene, nc_accession, alt_pos, and
-            strand
-        """
-        descr = await self.get_chr_assembly(genomic_tx_data["alt_ac"])
-        if descr is None:
-            # already grch38
-            return
-        chromosome, _ = descr
-
-        query = f"""
-            SELECT DISTINCT alt_ac
-            FROM {self.schema}.tx_exon_aln_v
-            WHERE tx_ac = '{genomic_tx_data['tx_ac']}';
-            """  # noqa: S608
-        nc_acs = await self.execute_query(query)
-        nc_acs = [nc_ac[0] for nc_ac in nc_acs]
-        if nc_acs == [genomic_tx_data["alt_ac"]]:
-            _logger.warning(
-                "UTA does not have GRCh38 assembly for %s",
-                genomic_tx_data["alt_ac"].split(".")[0],
-            )
-            return
-
-        # Get most recent assembly version position
-        # Liftover range
-        self._set_liftover(
-            genomic_tx_data, "alt_pos_range", chromosome, Assembly.GRCH38
-        )
-
-        # Liftover changes range
-        self._set_liftover(
-            genomic_tx_data, "alt_pos_change_range", chromosome, Assembly.GRCH38
-        )
-
-        # Change alt_ac to most recent
-        if genomic_tx_data["alt_ac"].startswith("EN"):
-            order_by_cond = "ORDER BY alt_ac DESC;"
-        else:
-            order_by_cond = """
-            ORDER BY CAST(SUBSTR(alt_ac, position('.' in alt_ac) + 1,
-            LENGTH(alt_ac)) AS INT) DESC;
-            """
-        query = f"""
-            SELECT alt_ac
-            FROM {self.schema}.genomic
-            WHERE alt_ac LIKE '{genomic_tx_data['alt_ac'].split('.')[0]}%'
-            {order_by_cond}
-            """  # noqa: S608
-        nc_acs = await self.execute_query(query)
-        genomic_tx_data["alt_ac"] = nc_acs[0][0]
-
-    def get_liftover(
-        self, chromosome: str, pos: int, liftover_to_assembly: Assembly
-    ) -> tuple[str, int] | None:
-        """Get new genome assembly data for a position on a chromosome.
-
-        Use a UCSC-style chromosome name:
-
-        >>> import asyncio
-        >>> from cool_seq_tool.sources import UtaDatabase
-        >>> from cool_seq_tool.schemas import Assembly
-        >>> uta = asyncio.run(UtaDatabase.create())
-        >>> asyncio.run(uta.get_liftover("chr5", 39998, Assembly.GRCH38))
-        ('chr7', 39998)
-
-        Chromosome names can also be NCBI-style, without prefixes:
-
-        >>> asyncio.run(uta.get_liftover("5", 39998, Assembly.GRCH38))
-        ('chr7', 39998)
-
-        :param chromosome: The chromosome number, e.g. ``"chr7"``, ``"chrX"``, ``"5"``.
-        :param pos: Position on the chromosome
-        :param liftover_to_assembly: Assembly to liftover to
-        :return: Target chromosome and target position for assembly
-        """
-        chromosome = process_chromosome_input(chromosome, "UtaDatabase.get_liftover()")
-        if liftover_to_assembly == Assembly.GRCH38:
-            liftover = self.liftover_37_to_38.convert_coordinate(chromosome, pos)
-        elif liftover_to_assembly == Assembly.GRCH37:
-            liftover = self.liftover_38_to_37.convert_coordinate(chromosome, pos)
-        else:
-            _logger.warning("%s assembly not supported", liftover_to_assembly)
-            liftover = None
-
-        if not liftover:
-            _logger.warning("%s does not exist on %s", pos, chromosome)
-            return None
-        return liftover[0][:2]
-
-    def _set_liftover(
-        self,
-        genomic_tx_data: dict,
-        key: str,
-        chromosome: str,
-        liftover_to_assembly: Assembly,
-    ) -> None:
-        """Update genomic_tx_data to have coordinates for given assembly.
-
-        :param genomic_tx_data: Dictionary containing gene, nc_accession, alt_pos, and
-            strand
-        :param key: Key to access coordinate positions
-        :param chromosome: Chromosome, must be prefixed with ``chr``
-        :param liftover_to_assembly: Assembly to liftover to
-        """
-        liftover_start_i = self.get_liftover(
-            chromosome, genomic_tx_data[key][0], liftover_to_assembly
-        )
-        if liftover_start_i is None:
-            _logger.warning(
-                "Unable to liftover position %s on %s",
-                genomic_tx_data[key][0],
-                chromosome,
-            )
-            return
-
-        liftover_end_i = self.get_liftover(
-            chromosome, genomic_tx_data[key][1], liftover_to_assembly
-        )
-        if liftover_end_i is None:
-            _logger.warning(
-                "Unable to liftover position %s on %s",
-                genomic_tx_data[key][1],
-                chromosome,
-            )
-            return
-
-        genomic_tx_data[key] = liftover_start_i[1], liftover_end_i[1]
 
     async def p_to_c_ac(self, p_ac: str) -> list[str]:
         """Return cDNA reference sequence accession from protein reference sequence

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from cool_seq_tool.app import CoolSeqTool
+from cool_seq_tool.schemas import Strand
 
 
 @pytest.fixture(scope="session")
@@ -102,3 +103,21 @@ def tpm3_1_8_start_genomic():
 def tpm3_1_8_end_genomic():
     """Create test fixture for genomic data for exon 1, 8"""
     return "TPM3", "NC_000001.11", 154170399, 154170469, -1
+
+
+@pytest.fixture(scope="session")
+def genomic_tx_data():
+    """Create test fixture for genomic_tx_data"""
+    return {
+        "gene": "BRAF",
+        "strand": Strand.NEGATIVE,
+        "tx_pos_range": (2053, 2188),
+        "alt_pos_range": (140439611, 140439746),
+        "alt_aln_method": "splign",
+        "tx_exon_id": 780496,
+        "alt_exon_id": 1927265,
+        "pos_change": (92, 43),
+        "alt_pos_change_range": (140439703, 140439703),
+        "tx_ac": "NM_004333.4",
+        "alt_ac": "NC_000007.13",
+    }

--- a/tests/mappers/test_liftover.py
+++ b/tests/mappers/test_liftover.py
@@ -1,0 +1,22 @@
+"""Module for testing LiftOver class"""
+
+import pytest
+
+from cool_seq_tool.schemas import Assembly
+
+
+@pytest.fixture(scope="module")
+def test_liftover(test_cool_seq_tool):
+    """Build LiftOver test fixture"""
+    return test_cool_seq_tool.liftover
+
+
+def test_get_liftover(test_liftover):
+    """Test that get_liftover works correctly."""
+    resp = test_liftover.get_liftover("chr7", 140453136, Assembly.GRCH38)
+    assert resp == ("chr7", 140753336)
+    resp = test_liftover.get_liftover("7", 140453136, Assembly.GRCH38)
+    assert resp == ("chr7", 140753336)
+
+    resp = test_liftover.get_liftover("chr17", 140453136, Assembly.GRCH38)
+    assert resp is None

--- a/tests/mappers/test_mane_transcript.py
+++ b/tests/mappers/test_mane_transcript.py
@@ -1,5 +1,6 @@
 """Module for testing MANE Transcript class."""
 
+from copy import deepcopy
 from unittest.mock import patch
 
 import polars as pl
@@ -281,6 +282,30 @@ async def test_g_to_c(
     expected.pos = (1798, 1800)
     expected.alt_ac = None
     assert mane_c == expected
+
+
+def test_set_liftover(test_mane_transcript, genomic_tx_data):
+    """Test that _set_liftover works correctly."""
+    cpy = deepcopy(genomic_tx_data)
+    expected = deepcopy(genomic_tx_data)
+    test_mane_transcript._set_liftover(cpy, "alt_pos_range", "chr7", "GRCh38")
+    expected["alt_pos_range"] = (140739811, 140739946)
+    assert cpy == expected
+    test_mane_transcript._set_liftover(cpy, "alt_pos_change_range", "chr7", "GRCh38")
+    expected["alt_pos_change_range"] = (140739903, 140739903)
+    assert cpy == expected
+
+
+@pytest.mark.asyncio()
+async def test_liftover_to_38(test_mane_transcript, genomic_tx_data):
+    """Test that liftover_to_38 works correctly."""
+    cpy = deepcopy(genomic_tx_data)
+    expected = deepcopy(genomic_tx_data)
+    await test_mane_transcript._liftover_to_38(cpy)
+    expected["alt_ac"] = "NC_000007.14"
+    expected["alt_pos_change_range"] = (140739903, 140739903)
+    expected["alt_pos_range"] = (140739811, 140739946)
+    assert cpy == expected
 
 
 def test_get_mane_p(test_mane_transcript, braf_mane_data, braf_v600e_mane_p):

--- a/tests/sources/test_uta_database.py
+++ b/tests/sources/test_uta_database.py
@@ -1,10 +1,8 @@
 """Test UTA data source."""
 
-import copy
-
 import pytest
 
-from cool_seq_tool.schemas import Assembly, Strand
+from cool_seq_tool.schemas import Strand
 
 
 @pytest.fixture(scope="module")
@@ -36,24 +34,6 @@ def data_from_result():
         "alt_aln_method": "splign",
         "tx_exon_id": 780494,
         "alt_exon_id": 1927263,
-    }
-
-
-@pytest.fixture(scope="module")
-def genomic_tx_data():
-    """Create test fixture for genomic_tx_data"""
-    return {
-        "gene": "BRAF",
-        "strand": Strand.NEGATIVE,
-        "tx_pos_range": (2053, 2188),
-        "alt_pos_range": (140439611, 140439746),
-        "alt_aln_method": "splign",
-        "tx_exon_id": 780496,
-        "alt_exon_id": 1927265,
-        "pos_change": (92, 43),
-        "alt_pos_change_range": (140439703, 140439703),
-        "tx_ac": "NM_004333.4",
-        "alt_ac": "NC_000007.13",
     }
 
 
@@ -317,41 +297,6 @@ async def test_get_chr_assembly(test_db):
     # Invalid ac
     resp = await test_db.get_chr_assembly("NC_00000714")
     assert resp is None
-
-
-@pytest.mark.asyncio()
-async def test_liftover_to_38(test_db, genomic_tx_data):
-    """Test that liftover_to_38 works correctly."""
-    cpy = copy.deepcopy(genomic_tx_data)
-    expected = copy.deepcopy(genomic_tx_data)
-    await test_db.liftover_to_38(cpy)
-    expected["alt_ac"] = "NC_000007.14"
-    expected["alt_pos_change_range"] = (140739903, 140739903)
-    expected["alt_pos_range"] = (140739811, 140739946)
-    assert cpy == expected
-
-
-def test_get_liftover(test_db):
-    """Test that get_liftover works correctly."""
-    resp = test_db.get_liftover("chr7", 140453136, Assembly.GRCH38)
-    assert resp == ("chr7", 140753336)
-    resp = test_db.get_liftover("7", 140453136, Assembly.GRCH38)
-    assert resp == ("chr7", 140753336)
-
-    resp = test_db.get_liftover("chr17", 140453136, Assembly.GRCH38)
-    assert resp is None
-
-
-def test_set_liftover(test_db, genomic_tx_data):
-    """Test that _set_liftover works correctly."""
-    cpy = copy.deepcopy(genomic_tx_data)
-    expected = copy.deepcopy(genomic_tx_data)
-    test_db._set_liftover(cpy, "alt_pos_range", "chr7", "GRCh38")
-    expected["alt_pos_range"] = (140739811, 140739946)
-    assert cpy == expected
-    test_db._set_liftover(cpy, "alt_pos_change_range", "chr7", "GRCh38")
-    expected["alt_pos_change_range"] = (140739903, 140739903)
-    assert cpy == expected
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
close #158

* Remove LiftOver from UtaDatabase class
* LiftOver separated into its own class
* ManeTranscript and ExonGenomicCoordsMapper now take liftover as param in init method

This PR only focuses on separating these two classes. I think a new issue could be made for cleaning up these classes.