### PR TITLE
feat: validate all inputs at once

### DIFF
--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -157,14 +157,14 @@ class ExonGenomicCoordsMapper:
         # Get all exons and associated start/end coordinates for transcript
         tx_exons, warning = await self.uta_db.get_tx_exons(transcript)
         if not tx_exons:
-            return self._return_warnings(resp, [warning] if warning else [""])
+            return self._return_warnings(resp, [warning] if warning else [])
 
         # Get exon start and exon end coordinates
         tx_exon_coords, warning = self.get_tx_exon_coords(
             transcript, tx_exons, exon_start, exon_end
         )
         if not tx_exon_coords:
-            return self._return_warnings(resp, [warning] if warning else [""])
+            return self._return_warnings(resp, [warning] if warning else [])
         tx_exon_start_coords, tx_exon_end_coords = tx_exon_coords
 
         if gene:
@@ -176,7 +176,7 @@ class ExonGenomicCoordsMapper:
             transcript, tx_exon_start_coords, tx_exon_end_coords, gene=gene
         )
         if not alt_ac_start_end:
-            return self._return_warnings(resp, [warning] if warning else [""])
+            return self._return_warnings(resp, [warning] if warning else [])
         alt_ac_start_data, alt_ac_end_data = alt_ac_start_end
 
         # Get gene and chromosome data, check that at least one was retrieved

--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -278,6 +278,8 @@ class ExonGenomicCoordsMapper:
             breakpoint for the 3' end. For the negative strand, adjacent is defined as
             the exon following the breakpoint for the 5' end and the exon preceding the
             breakpoint for the 3' end.
+        :param gene: gene name. Ideally, HGNC symbol. Must be given if no ``transcript``
+            value is provided.
         :param residue_mode: Residue mode for ``start`` and ``end``
         :return: Genomic data (inter-residue coordinates)
         """
@@ -289,6 +291,10 @@ class ExonGenomicCoordsMapper:
         if chromosome is None and alt_ac is None:
             return self._return_warnings(
                 resp, "Must provide either `chromosome` or `alt_ac`"
+            )
+        if transcript is None and gene is None:
+            return self._return_warnings(
+                resp, "Must provide either `gene` or `transcript`"
             )
 
         params = {key: None for key in GenomicData.model_fields}
@@ -513,12 +519,6 @@ class ExonGenomicCoordsMapper:
         resp = TranscriptExonDataResponse(
             transcript_exon_data=None, warnings=[], service_meta=service_meta()
         )
-
-        if transcript is None and gene is None:
-            return self._return_warnings(
-                resp, "Must provide either `gene` or `transcript`"
-            )
-
         params = {key: None for key in TranscriptExonData.model_fields}
 
         if get_nearest_transcript_junction:

--- a/tests/mappers/test_exon_genomic_coords.py
+++ b/tests/mappers/test_exon_genomic_coords.py
@@ -1089,10 +1089,10 @@ async def test_invalid(test_egc_mapper):
     ]
 
     # Must supply either gene or transcript
-    resp = await test_egc_mapper._genomic_to_transcript_exon_coordinate(
-        154192135, alt_ac="NC_000001.11", strand=Strand.POSITIVE
+    resp = await test_egc_mapper.genomic_to_transcript_exon_coordinates(
+        start=154192135, alt_ac="NC_000001.11", strand=Strand.POSITIVE
     )
-    transcript_exon_data_assertion_checks(resp, is_valid=False)
+    genomic_data_assertion_checks(resp, is_valid=False)
     assert resp.warnings == ["Must provide either `gene` or `transcript`"]
 
     # Exon 22 does not exist
@@ -1123,7 +1123,10 @@ async def test_invalid(test_egc_mapper):
         exon_start=-1, exon_end=0, transcript="NM_152263.3"
     )
     genomic_data_assertion_checks(resp, is_valid=False)
-    assert resp.warnings == ["`exon_start` cannot be less than 1"]
+    assert resp.warnings == [
+        "`exon_start` cannot be less than 1",
+        "`exon_end` cannot be less than 1",
+    ]
 
     # Cant supply 0 based exons
     resp = await test_egc_mapper.transcript_to_genomic_coordinates(


### PR DESCRIPTION
close #313 

These had become kind of scattered, and each "warning" would insta-return rather than waiting to see if other inputs were also invalid. I wouldn't say that this is an exhaustive overhaul but it moves a check closer to the original call and also lets other checks occur where it seems easy to let them run.