### PR TITLE
chore: rename optional dependency

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -17,7 +17,7 @@ Create a virtual environment and install :ref:`all dependency groups<dependency-
 
     python3 -m venv venv
     source venv/bin/activate
-    python3 -m pip install -e ".[dev,tests,docs]"
+    python3 -m pip install -e ".[dev,test,docs]"
 
 We use `pre-commit <https://pre-commit.com/#usage>`_ to run conformance tests before commits. This provides checks for:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -24,7 +24,7 @@ Install Cool-Seq-Tool from `PyPI <https://pypi.org/project/cool-seq-tool/>`_:
    Cool-Seq-Tool provides extra dependency groups for development and testing purposes. Most users won't need to install them.
 
    * ``dev`` includes packages for linting and performing other kinds of quality checks
-   * ``tests`` includes packages for running tests
+   * ``test`` includes packages for running tests
    * ``docs`` includes packages for writing and building documentation
 
 Set up UTA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.7.1", "ipython", "ipykernel", "psycopg2-binary", "ruff==0.5.0"]
-tests = ["pytest", "pytest-cov", "pytest-asyncio==0.18.3", "mock"]
+test = ["pytest", "pytest-cov", "pytest-asyncio==0.18.3", "mock"]
 docs = [
     "sphinx==6.1.3",
     "sphinx-autodoc-typehints==1.22.0",


### PR DESCRIPTION
* `tests` -> `test`

Just to be consistent with template repo