### PR TITLE
feat!: only return cdna representation in `g_to_mane_c`

### DIFF
--- a/src/cool_seq_tool/mappers/mane_transcript.py
+++ b/src/cool_seq_tool/mappers/mane_transcript.py
@@ -71,10 +71,9 @@ class CdnaRepresentation(DataRepresentation):
 class GenomicRepresentation(BaseModel):
     """Define object model for genomic representation"""
 
-    refseq: str
     pos: tuple[int, int]
-    status: TranscriptPriority
-    alt_ac: str
+    status: Literal["grch38"] = TranscriptPriority.GRCH38.value
+    ac: str
 
 
 class ProteinAndCdnaRepresentation(BaseModel):
@@ -108,7 +107,7 @@ class ManeTranscript:
 
         >>> import asyncio
         >>> result = asyncio.run(mane_mapper.g_to_grch38("NC_000001.11", 100, 200))
-        >>> result["ac"]
+        >>> result.ac
         'NC_000001.11'
 
         See the :ref:`Usage section <async_note>` for more information.
@@ -983,7 +982,11 @@ class ManeTranscript:
         :param start_pos: Start position change
         :param end_pos: End position change
         :param start_annotation_layer: Starting annotation layer.
-        :param gene: HGNC gene symbol
+        :param gene: HGNC gene symbol.
+            If gene is not provided and ``start_annotation_layer`` is
+            ``AnnotationLayer.GENOMIC``, will return GRCh38 representation.
+            If gene is provided and ``start_annotation_layer`` is
+            ``AnnotationLayer.GENOMIC``, will return MANE cDNA representation.
         :param ref: Reference at position given during input
         :param try_longest_compatible: ``True`` if should try longest compatible remaining
             if mane transcript was not compatible. ``False`` otherwise.
@@ -1093,29 +1096,46 @@ class ManeTranscript:
                 )
             return None
         if start_annotation_layer == AnnotationLayer.GENOMIC:
+            # If gene not provided, return GRCh38
+            if not gene:
+                return await self.g_to_grch38(
+                    ac,
+                    start_pos,
+                    end_pos,
+                    get_mane_genes=True,
+                    residue_mode=residue_mode,
+                )
+
             return await self.g_to_mane_c(
-                ac, start_pos, end_pos, gene=gene, residue_mode=residue_mode
+                ac, start_pos, end_pos, gene, residue_mode=residue_mode
             )
         _logger.warning("Annotation layer not supported: %s", start_annotation_layer)
         return None
 
-    async def g_to_grch38(self, ac: str, start_pos: int, end_pos: int) -> dict | None:
+    async def g_to_grch38(
+        self,
+        ac: str,
+        start_pos: int,
+        end_pos: int,
+        residue_mode: ResidueMode = ResidueMode.RESIDUE,
+    ) -> GenomicRepresentation | None:
         """Return genomic coordinate on GRCh38 when not given gene context.
 
         :param ac: Genomic accession
         :param start_pos: Genomic start position
         :param end_pos: Genomic end position
-        :return: NC accession, start and end pos on GRCh38 assembly
+        :param residue_mode: Residue mode for ``start_pos`` and ``end_pos``
+        :return: GRCh38 genomic representation (accession and start/end inter-residue
+            position)
         """
-        if end_pos is None:
-            end_pos = start_pos
+        start_pos, end_pos = get_inter_residue_pos(start_pos, end_pos, residue_mode)
 
         # Checking to see what chromosome and assembly we're on
         descr = await self.uta_db.get_chr_assembly(ac)
         if not descr:
             # Already GRCh38 assembly
             if self._validate_index(ac, (start_pos, end_pos), 0):
-                return {"ac": ac, "pos": (start_pos, end_pos)}
+                return GenomicRepresentation(ac=ac, pos=(start_pos, end_pos))
             return None
         chromosome, assembly = descr
         is_same_pos = start_pos == end_pos
@@ -1146,7 +1166,7 @@ class ManeTranscript:
         if newest_ac:
             ac = newest_ac[0]
             if self._validate_index(ac, (start_pos, end_pos), 0):
-                return {"ac": ac, "pos": (start_pos, end_pos)}
+                return GenomicRepresentation(ac=ac, pos=(start_pos, end_pos))
         return None
 
     @staticmethod
@@ -1176,13 +1196,10 @@ class ManeTranscript:
         ac: str,
         start_pos: int,
         end_pos: int,
-        gene: str | None = None,
+        gene: str,
         residue_mode: ResidueMode = ResidueMode.RESIDUE,
-    ) -> GenomicRepresentation | CdnaRepresentation | None:
+    ) -> CdnaRepresentation | None:
         """Return MANE Transcript on the c. coordinate.
-
-        If an arg for ``gene`` is provided, lifts to GRCh38, then gets MANE cDNA
-        representation.
 
         >>> import asyncio
         >>> from cool_seq_tool.app import CoolSeqTool
@@ -1198,33 +1215,16 @@ class ManeTranscript:
         <TranscriptPriority.MANE_SELECT: 'mane_select'>
         >>> del cst
 
-        Locating a MANE transcript requires a ``gene`` symbol argument -- if none is
-        given, this method will only lift over to genomic coordinates on GRCh38.
-
         :param ac: Transcript accession on g. coordinate
         :param start_pos: genomic start position
         :param end_pos: genomic end position
         :param gene: HGNC gene symbol
         :param residue_mode: Starting residue mode for ``start_pos`` and ``end_pos``.
             Will always return coordinates in inter-residue.
-        :return: MANE Transcripts with cDNA change on c. coordinate if gene
-            is provided. Else, GRCh38 data
+        :return: MANE Transcripts with cDNA change on c. coordinate
         """
         start_pos, end_pos = get_inter_residue_pos(start_pos, end_pos, residue_mode)
         residue_mode = ResidueMode.INTER_RESIDUE
-
-        # If gene not provided, return GRCh38
-        if not gene:
-            grch38 = await self.g_to_grch38(ac, start_pos, end_pos)
-            if not grch38:
-                return None
-
-            return GenomicRepresentation(
-                refseq=grch38["ac"],
-                pos=grch38["pos"],
-                status=TranscriptPriority.GRCH38,
-                alt_ac=grch38["ac"],
-            )
 
         if not await self.uta_db.validate_genomic_ac(ac):
             _logger.warning("Genomic accession does not exist: %s", ac)
@@ -1238,12 +1238,14 @@ class ManeTranscript:
             mane_c_ac = current_mane_data["RefSeq_nuc"]
 
             # Liftover to GRCh38
-            grch38 = await self.g_to_grch38(ac, start_pos, end_pos)
+            grch38 = await self.g_to_grch38(
+                ac, start_pos, end_pos, residue_mode=residue_mode
+            )
             mane_tx_genomic_data = None
             if grch38:
                 # GRCh38 -> MANE C
                 mane_tx_genomic_data = await self.uta_db.get_mane_c_genomic_data(
-                    mane_c_ac, grch38["ac"], grch38["pos"][0], grch38["pos"][1]
+                    mane_c_ac, grch38.ac, grch38.pos[0], grch38.pos[1]
                 )
 
             if not grch38 or not mane_tx_genomic_data:
@@ -1284,7 +1286,7 @@ class ManeTranscript:
                 ),
                 refseq_c_ac=current_mane_data["RefSeq_nuc"],
                 ensembl_c_ac=current_mane_data["Ensembl_nuc"],
-                alt_ac=grch38["ac"] if grch38 else None,
+                alt_ac=grch38.ac if grch38 else None,
             )
         return None
 

--- a/src/cool_seq_tool/mappers/mane_transcript.py
+++ b/src/cool_seq_tool/mappers/mane_transcript.py
@@ -961,7 +961,16 @@ class ManeTranscript:
         residue_mode: Literal[ResidueMode.RESIDUE]
         | Literal[ResidueMode.INTER_RESIDUE] = ResidueMode.RESIDUE,
     ) -> DataRepresentation | CdnaRepresentation | None:
-        """Return MANE transcript.
+        """Return MANE representation
+
+        If ``start_annotation_layer`` is ``AnnotationLayer.PROTEIN``, will return
+            ``AnnotationLayer.PROTEIN`` representation.
+        If ``start_annotation_layer`` is ``AnnotationLayer.CDNA``, will return
+            ``AnnotationLayer.CDNA`` representation.
+        If ``start_annotation_layer`` is ``AnnotationLayer.GENOMIC`` will return
+            ``AnnotationLayer.CDNA`` representation if ``gene`` is provided and
+            ``AnnotationLayer.GENOMIC`` GRCh38 representation if ``gene`` is NOT
+            provided.
 
         >>> from cool_seq_tool.app import CoolSeqTool
         >>> from cool_seq_tool.schemas import AnnotationLayer, ResidueMode
@@ -983,10 +992,10 @@ class ManeTranscript:
         :param end_pos: End position change
         :param start_annotation_layer: Starting annotation layer.
         :param gene: HGNC gene symbol.
-            If gene is not provided and ``start_annotation_layer`` is
+            If ``gene`` is not provided and ``start_annotation_layer`` is
             ``AnnotationLayer.GENOMIC``, will return GRCh38 representation.
-            If gene is provided and ``start_annotation_layer`` is
-            ``AnnotationLayer.GENOMIC``, will return MANE cDNA representation.
+            If ``gene`` is provided and ``start_annotation_layer`` is
+            ``AnnotationLayer.GENOMIC``, will return cDNA representation.
         :param ref: Reference at position given during input
         :param try_longest_compatible: ``True`` if should try longest compatible remaining
             if mane transcript was not compatible. ``False`` otherwise.
@@ -1096,7 +1105,6 @@ class ManeTranscript:
                 )
             return None
         if start_annotation_layer == AnnotationLayer.GENOMIC:
-            # If gene not provided, return GRCh38
             if not gene:
                 return await self.g_to_grch38(
                     ac,


### PR DESCRIPTION
close #320

* `gene` is now a required arg in `g_to_mane_c`
* Move `g_to_grch38` call outside of `g_to_mane_c`, so that only `CdnaRepresentation` is returned
* Update `GenomicRepresentation` model
  * Remove `refseq` (this was a duplicate of `alt_ac`/`ac`)
  * Rename `alt_ac` to `ac`
  * `status` is set to literal 'grch38'
* `g_to_grch38` now returns `GenomicRepresentation` instead of dict. Also has `residue_mode` arg