### PR TITLE
feat: enable direct import of CST from package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See the [installation instructions](https://coolseqtool.readthedocs.io/latest/in
 All CoolSeqTool resources can be initialized by way of a top-level class instance:
 
 ```pycon
->>> from cool_seq_tool.app import CoolSeqTool
+>>> from cool_seq_tool import CoolSeqTool
 >>> from cool_seq_tool.schemas import AnnotationLayer, ResidueMode
 >>> cst = CoolSeqTool()
 >>> result = await cst.mane_transcript.get_mane_transcript(

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -15,7 +15,7 @@ The core :py:class:`CoolSeqTool <cool_seq_tool.app.CoolSeqTool>` class encapsula
 
 .. code-block:: pycon
 
-   >>> from cool_seq_tool.app import CoolSeqTool
+   >>> from cool_seq_tool import CoolSeqTool
    >>> cst = CoolSeqTool()
    >>> cst.seqrepo_access.translate_alias("NM_002529.3")[0][-1]
    'ga4gh:SQ.RSkww1aYmsMiWbNdNnOTnVDAM3ZWp1uA'
@@ -34,7 +34,7 @@ Descriptions and examples of functions can be found in the :ref:`API Reference <
 
    .. code-block:: python
 
-       from cool_seq_tool.app import CoolSeqTool
+       from cool_seq_tool import CoolSeqTool
 
        async def do_thing():
            mane_mapper = CoolSeqTool().mane_transcript
@@ -50,7 +50,7 @@ Descriptions and examples of functions can be found in the :ref:`API Reference <
    .. code-block:: pycon
 
       >>> import asyncio
-      >>> from cool_seq_tool.app import cool_seq_tool
+      >>> from cool_seq_tool import cool_seq_tool
       >>> mane_mapper = CoolSeqTool().mane_transcript
       >>> result = asyncio.run(mane_mapper.g_to_grch38("NC_000001.11", 100, 200))
       >>> print(result)

--- a/src/cool_seq_tool/__init__.py
+++ b/src/cool_seq_tool/__init__.py
@@ -8,3 +8,8 @@ except PackageNotFoundError:
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError
+
+
+from cool_seq_tool.app import CoolSeqTool
+
+__all__ = ["CoolSeqTool", "__version__"]

--- a/src/cool_seq_tool/app.py
+++ b/src/cool_seq_tool/app.py
@@ -48,7 +48,7 @@ class CoolSeqTool:
 
         Initialization with default resource locations is straightforward:
 
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> cst = CoolSeqTool()
 
         By default, this will attempt to fetch the latest versions of static resources,

--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -45,7 +45,7 @@ class ExonGenomicCoordsMapper:
         A lot of resources are required for initialization, so when defaults are enough,
         it's easiest to let the core CoolSeqTool class handle it for you:
 
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> egc = CoolSeqTool().ex_g_coords_mapper
 
         Note that this class's public methods are all defined as ``async``, so they will
@@ -103,7 +103,7 @@ class ExonGenomicCoordsMapper:
         By default, transcript data is aligned to the GRCh38 assembly.
 
         >>> import asyncio
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> egc = CoolSeqTool().ex_g_coords_mapper
         >>> tpm3 = asyncio.run(
         ...     egc.transcript_to_genomic_coordinates(
@@ -252,7 +252,7 @@ class ExonGenomicCoordsMapper:
         supplied. ``gene`` must be given in order to retrieve MANE Transcript data.
 
         >>> import asyncio
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> from cool_seq_tool.schemas import Strand
         >>> egc = CoolSeqTool().ex_g_coords_mapper
         >>> result = asyncio.run(

--- a/src/cool_seq_tool/mappers/mane_transcript.py
+++ b/src/cool_seq_tool/mappers/mane_transcript.py
@@ -101,7 +101,7 @@ class ManeTranscript:
         A handful of resources are required for initialization, so when defaults are
         enough, it's easiest to let the core CoolSeqTool class handle it for you:
 
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> mane_mapper = CoolSeqTool().mane_transcript
 
         Note that most methods are defined as Python coroutines, so they must be called
@@ -700,7 +700,7 @@ class ManeTranscript:
         information.
 
         >>> import asyncio
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> from cool_seq_tool.schemas import AnnotationLayer, ResidueMode
         >>> mane_mapper = CoolSeqTool().mane_transcript
         >>> mane_transcripts = {
@@ -974,7 +974,7 @@ class ManeTranscript:
             ``AnnotationLayer.GENOMIC`` GRCh38 representation if ``gene`` is NOT
             provided.
 
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> from cool_seq_tool.schemas import AnnotationLayer, ResidueMode
         >>> import asyncio
         >>> mane_mapper = CoolSeqTool().mane_transcript
@@ -1231,7 +1231,7 @@ class ManeTranscript:
         """Return MANE Transcript on the c. coordinate.
 
         >>> import asyncio
-        >>> from cool_seq_tool.app import CoolSeqTool
+        >>> from cool_seq_tool import CoolSeqTool
         >>> cst = CoolSeqTool()
         >>> result = asyncio.run(
         ...     cst.mane_transcript.g_to_mane_c(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from cool_seq_tool.app import CoolSeqTool
+from cool_seq_tool import CoolSeqTool
 from cool_seq_tool.schemas import ManeGeneData, Strand
 
 


### PR DESCRIPTION
Small quality of life change: enable `from cool_seq_tool import CoolSeqTool` rather than just `from cool_seq_tool.app import CoolSeqTool`.

I tried a few different import statements, and tests pass, so I don't think this will cause any new import errors.