### PR TITLE
docs: link to stable, not latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CoolSeqTool
 
 ---
 
-**[Documentation](https://coolseqtool.readthedocs.io/latest/)** · [Installation](https://coolseqtool.readthedocs.io/latest/install.html) · [Usage](https://coolseqtool.readthedocs.io/latest/usage.html) · [API reference](https://coolseqtool.readthedocs.io/latest/reference/index.html)
+**[Documentation](https://coolseqtool.readthedocs.io/stable/)** · [Installation](https://coolseqtool.readthedocs.io/stable/install.html) · [Usage](https://coolseqtool.readthedocs.io/stable/usage.html) · [API reference](https://coolseqtool.readthedocs.io/stable/reference/index.html)
 
 ---
 
@@ -30,7 +30,7 @@ CoolSeqTool is available on [PyPI](https://pypi.org/project/cool-seq-tool)
 python3 -m pip install cool-seq-tool
 ```
 
-See the [installation instructions](https://coolseqtool.readthedocs.io/latest/install.html) in the documentation for a description of dependency setup requirements.
+See the [installation instructions](https://coolseqtool.readthedocs.io/stable/install.html) in the documentation for a description of dependency setup requirements.
 
 ---
 
@@ -56,4 +56,4 @@ All CoolSeqTool resources can be initialized by way of a top-level class instanc
 
 ## Feedback and contributing
 
-We welcome bug reports, feature requests, and code contributions from users and interested collaborators. The [documentation](https://coolseqtool.readthedocs.io/latest/contributing.html) contains guidance for submitting feedback and contributing new code.
+We welcome bug reports, feature requests, and code contributions from users and interested collaborators. The [documentation](https://coolseqtool.readthedocs.io/stable/contributing.html) contains guidance for submitting feedback and contributing new code.


### PR DESCRIPTION
`Latest` refers to a build that sources from the most recent GitHub commit, whereas `Stable` is the most recent release. I imagine this will rarely matter but I think it's better to direct to docs that represent what can be installed from PyPI rather than the most recent possible code.