### PR TITLE
refactor: rename `is_start` kwarg in private methods to `is_seg_start`

### DIFF
--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -20,7 +20,7 @@ from cool_seq_tool.utils import service_meta
 _logger = logging.getLogger(__name__)
 
 
-class ExonCoord(BaseModelForbidExtra):
+class _ExonCoord(BaseModelForbidExtra):
     """Model for representing exon coordinate data"""
 
     ord: StrictInt = Field(..., description="Exon number. 0-based.")
@@ -527,7 +527,7 @@ class ExonGenomicCoordsMapper:
 
     async def _get_all_exon_coords(
         self, tx_ac: str, genomic_ac: str | None = None
-    ) -> list[ExonCoord]:
+    ) -> list[_ExonCoord]:
         """Get all exon coordinate data for a transcript.
 
         If ``genomic_ac`` is NOT provided, this method will use the GRCh38 accession
@@ -563,7 +563,7 @@ class ExonGenomicCoordsMapper:
                 """  # noqa: S608
 
         results = await self.uta_db.execute_query(query)
-        return [ExonCoord(**r) for r in results]
+        return [_ExonCoord(**r) for r in results]
 
     async def _get_start_end_exon_coords(
         self,
@@ -571,7 +571,7 @@ class ExonGenomicCoordsMapper:
         exon_start: int | None = None,
         exon_end: int | None = None,
         genomic_ac: str | None = None,
-    ) -> tuple[ExonCoord | None, ExonCoord | None, list[str]]:
+    ) -> tuple[_ExonCoord | None, _ExonCoord | None, list[str]]:
         """Get exon coordinates for a transcript given exon start and exon end.
 
         If ``genomic_ac`` is NOT provided, this method will use the GRCh38 accession
@@ -609,8 +609,8 @@ class ExonGenomicCoordsMapper:
     async def _get_alt_ac_start_and_end(
         self,
         tx_ac: str,
-        tx_exon_start: ExonCoord | None = None,
-        tx_exon_end: ExonCoord | None = None,
+        tx_exon_start: _ExonCoord | None = None,
+        tx_exon_end: _ExonCoord | None = None,
         gene: str | None = None,
     ) -> tuple[tuple[tuple[int, int], tuple[int, int]] | None, str | None]:
         """Get aligned genomic coordinates for transcript exon start and end.
@@ -948,7 +948,7 @@ class ExonGenomicCoordsMapper:
         genomic_ac: str,
         strand: Strand,
         offset: int,
-        genomic_ac_data: ExonCoord,
+        genomic_ac_data: _ExonCoord,
         is_seg_start: bool = False,
     ) -> tuple[TxSegment | None, str | None]:
         """Get transcript segment data given ``genomic_ac`` and offset data
@@ -1153,7 +1153,7 @@ class ExonGenomicCoordsMapper:
 
     @staticmethod
     def _get_adjacent_exon(
-        tx_exons_genomic_coords: list[ExonCoord],
+        tx_exons_genomic_coords: list[_ExonCoord],
         strand: Strand,
         start: int | None = None,
         end: int | None = None,
@@ -1191,7 +1191,7 @@ class ExonGenomicCoordsMapper:
         return exon.ord if end else exon.ord + 1
 
     @staticmethod
-    def _is_exonic_breakpoint(pos: int, tx_genomic_coords: list[ExonCoord]) -> bool:
+    def _is_exonic_breakpoint(pos: int, tx_genomic_coords: list[_ExonCoord]) -> bool:
         """Check if a breakpoint occurs on an exon
 
         :param pos: Genomic breakpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import asyncio
 import pytest
 
 from cool_seq_tool import CoolSeqTool
-from cool_seq_tool.mappers.exon_genomic_coords import ExonCoord
+from cool_seq_tool.mappers.exon_genomic_coords import _ExonCoord
 from cool_seq_tool.schemas import ManeGeneData, Strand
 from cool_seq_tool.sources.uta_database import GenomicAlnData, GenomicTxMetadata
 
@@ -52,7 +52,7 @@ def test_mane_transcript_mappings(test_cool_seq_tool):
 def nm_152263_exons():
     """Create test fixture for NM_152263.3 exons."""
     return [
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=234,
@@ -60,7 +60,7 @@ def nm_152263_exons():
             alt_end_i=154192135,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=1,
             tx_start_i=234,
             tx_end_i=360,
@@ -68,7 +68,7 @@ def nm_152263_exons():
             alt_end_i=154191311,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=2,
             tx_start_i=360,
             tx_end_i=494,
@@ -76,7 +76,7 @@ def nm_152263_exons():
             alt_end_i=154176248,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=3,
             tx_start_i=494,
             tx_end_i=612,
@@ -84,7 +84,7 @@ def nm_152263_exons():
             alt_end_i=154173201,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=4,
             tx_start_i=612,
             tx_end_i=683,
@@ -92,7 +92,7 @@ def nm_152263_exons():
             alt_end_i=154172978,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=5,
             tx_start_i=683,
             tx_end_i=759,
@@ -100,7 +100,7 @@ def nm_152263_exons():
             alt_end_i=154171488,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=6,
             tx_start_i=759,
             tx_end_i=822,
@@ -108,7 +108,7 @@ def nm_152263_exons():
             alt_end_i=154170711,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=7,
             tx_start_i=822,
             tx_end_i=892,
@@ -116,7 +116,7 @@ def nm_152263_exons():
             alt_end_i=154170469,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=8,
             tx_start_i=892,
             tx_end_i=971,
@@ -124,7 +124,7 @@ def nm_152263_exons():
             alt_end_i=154169383,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=9,
             tx_start_i=971,
             tx_end_i=7099,
@@ -139,7 +139,7 @@ def nm_152263_exons():
 def nm_152263_exons_genomic_coords():
     """Create test fixture for NM_152263.4 exons and genomic coordinates."""
     return [
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=199,
@@ -147,7 +147,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154192100,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=1,
             tx_start_i=199,
             tx_end_i=325,
@@ -155,7 +155,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154191311,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=2,
             tx_start_i=325,
             tx_end_i=459,
@@ -163,7 +163,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154176248,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=3,
             tx_start_i=459,
             tx_end_i=577,
@@ -171,7 +171,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154173201,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=4,
             tx_start_i=577,
             tx_end_i=648,
@@ -179,7 +179,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154172978,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=5,
             tx_start_i=648,
             tx_end_i=724,
@@ -187,7 +187,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154171488,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=6,
             tx_start_i=724,
             tx_end_i=787,
@@ -195,7 +195,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154170711,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=7,
             tx_start_i=787,
             tx_end_i=857,
@@ -203,7 +203,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154170469,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=8,
             tx_start_i=857,
             tx_end_i=936,
@@ -211,7 +211,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154169383,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=9,
             tx_start_i=936,
             tx_end_i=7064,
@@ -226,7 +226,7 @@ def nm_152263_exons_genomic_coords():
 def nm_001105539_exons_genomic_coords():
     """Create test fixture for NM_001105539.3 exons and genomic coordinates."""
     return [
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=1557,
@@ -234,7 +234,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80487782,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=1,
             tx_start_i=1557,
             tx_end_i=2446,
@@ -242,7 +242,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80500382,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=2,
             tx_start_i=2446,
             tx_end_i=2545,
@@ -250,7 +250,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80514008,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=3,
             tx_start_i=2545,
             tx_end_i=2722,
@@ -258,7 +258,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80518579,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=4,
             tx_start_i=2722,
             tx_end_i=2895,
@@ -266,7 +266,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80518954,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=5,
             tx_start_i=2895,
             tx_end_i=9938,

--- a/tests/mappers/test_exon_genomic_coords.py
+++ b/tests/mappers/test_exon_genomic_coords.py
@@ -5,9 +5,9 @@ from datetime import datetime
 import pytest
 
 from cool_seq_tool.mappers.exon_genomic_coords import (
-    ExonCoord,
     GenomicTxSeg,
     GenomicTxSegService,
+    _ExonCoord,
 )
 from cool_seq_tool.schemas import (
     Strand,
@@ -24,7 +24,7 @@ def test_egc_mapper(test_cool_seq_tool):
 def nm_152263_exons_genomic_coords():
     """Create test fixture for NM_152263.4 exons and genomic coordinates."""
     return [
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=199,
@@ -32,7 +32,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154192100,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=1,
             tx_start_i=199,
             tx_end_i=325,
@@ -40,7 +40,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154191311,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=2,
             tx_start_i=325,
             tx_end_i=459,
@@ -48,7 +48,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154176248,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=3,
             tx_start_i=459,
             tx_end_i=577,
@@ -56,7 +56,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154173201,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=4,
             tx_start_i=577,
             tx_end_i=648,
@@ -64,7 +64,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154172978,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=5,
             tx_start_i=648,
             tx_end_i=724,
@@ -72,7 +72,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154171488,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=6,
             tx_start_i=724,
             tx_end_i=787,
@@ -80,7 +80,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154170711,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=7,
             tx_start_i=787,
             tx_end_i=857,
@@ -88,7 +88,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154170469,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=8,
             tx_start_i=857,
             tx_end_i=936,
@@ -96,7 +96,7 @@ def nm_152263_exons_genomic_coords():
             alt_end_i=154169383,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=9,
             tx_start_i=936,
             tx_end_i=7064,
@@ -111,7 +111,7 @@ def nm_152263_exons_genomic_coords():
 def nm_001105539_exons_genomic_coords():
     """Create test fixture for NM_001105539.3 exons and genomic coordinates."""
     return [
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=1557,
@@ -119,7 +119,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80487782,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=1,
             tx_start_i=1557,
             tx_end_i=2446,
@@ -127,7 +127,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80500382,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=2,
             tx_start_i=2446,
             tx_end_i=2545,
@@ -135,7 +135,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80514008,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=3,
             tx_start_i=2545,
             tx_end_i=2722,
@@ -143,7 +143,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80518579,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=4,
             tx_start_i=2722,
             tx_end_i=2895,
@@ -151,7 +151,7 @@ def nm_001105539_exons_genomic_coords():
             alt_end_i=80518954,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=5,
             tx_start_i=2895,
             tx_end_i=9938,
@@ -774,7 +774,7 @@ async def test_get_start_end_exon_coords(test_egc_mapper):
         "NM_152263.3", exon_start=1, exon_end=8
     )
     assert resp == (
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=234,
@@ -782,7 +782,7 @@ async def test_get_start_end_exon_coords(test_egc_mapper):
             alt_end_i=154192135,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=7,
             tx_start_i=822,
             tx_end_i=892,
@@ -958,7 +958,7 @@ async def test_get_alt_ac_start_and_end(
     """Test that _get_alt_ac_start_and_end works correctly."""
     resp = await test_egc_mapper._get_alt_ac_start_and_end(
         "NM_152263.3",
-        ExonCoord(
+        _ExonCoord(
             ord=0,
             tx_start_i=0,
             tx_end_i=234,
@@ -966,7 +966,7 @@ async def test_get_alt_ac_start_and_end(
             alt_end_i=154192135,
             alt_strand=Strand.NEGATIVE,
         ),
-        ExonCoord(
+        _ExonCoord(
             ord=7,
             tx_start_i=822,
             tx_end_i=892,

--- a/tests/mappers/test_exon_genomic_coords.py
+++ b/tests/mappers/test_exon_genomic_coords.py
@@ -1020,7 +1020,7 @@ async def test_genomic_to_transcript(test_egc_mapper, tpm3_exon1, tpm3_exon8):
         154170399,
         genomic_ac="NC_000001.11",
         transcript="NM_152263.3",
-        is_start=False,
+        is_seg_start=False,
     )
     genomic_tx_seg_checks(resp, tpm3_exon8)
 
@@ -1028,12 +1028,12 @@ async def test_genomic_to_transcript(test_egc_mapper, tpm3_exon1, tpm3_exon8):
         154170399,
         chromosome="1",
         transcript="NM_152263.3",
-        is_start=False,
+        is_seg_start=False,
     )
     genomic_tx_seg_checks(resp, tpm3_exon8)
 
     resp = await test_egc_mapper._genomic_to_tx_segment(
-        154170399, chromosome="1", transcript="NM_152263.3", is_start=False
+        154170399, chromosome="1", transcript="NM_152263.3", is_seg_start=False
     )
     genomic_tx_seg_checks(resp, tpm3_exon8)
 


### PR DESCRIPTION
addresses #224

@jsstevenson not sure what our convention is if a breaking change occurs in private methods. Theoretically, since they have a leading underscore they are meant to be internal but if people still choose to use these methods they should be aware? Kept going back and forth on this (as I always do with conventional commits it feels like).