### PR TITLE
refactor: remove duplicate `genomic_ac` check

### DIFF
--- a/src/cool_seq_tool/mappers/exon_genomic_coords.py
+++ b/src/cool_seq_tool/mappers/exon_genomic_coords.py
@@ -878,20 +878,17 @@ class ExonGenomicCoordsMapper:
                 )
 
         if genomic_ac:
-            # Check if valid accession is given
-            if not await self.uta_db.validate_genomic_ac(genomic_ac):
-                return GenomicTxSeg(errors=[f"Invalid genomic accession: {genomic_ac}"])
-
             _gene, err_msg = await self._get_genomic_ac_gene(genomic_pos, genomic_ac)
-            if _gene:
-                if gene and _gene != gene:
-                    return GenomicTxSeg(
-                        errors=[f"Expected gene, {gene}, but found {_gene}"]
-                    )
 
-                gene = _gene
-            else:
+            if err_msg:
                 return GenomicTxSeg(errors=[err_msg])
+
+            if gene and _gene != gene:
+                return GenomicTxSeg(
+                    errors=[f"Expected gene, {gene}, but found {_gene}"]
+                )
+
+            gene = _gene
         elif chromosome:
             # Try GRCh38 first
             for assembly in [Assembly.GRCH38.value, Assembly.GRCH37.value]:

--- a/tests/mappers/test_exon_genomic_coords.py
+++ b/tests/mappers/test_exon_genomic_coords.py
@@ -1376,7 +1376,7 @@ async def test_invalid(test_egc_mapper):
         transcript="NM_152263.3",
     )
     genomic_tx_seg_service_checks(resp, is_valid=False)
-    assert resp.errors == ["Invalid genomic accession: NC_000001.200"]
+    assert resp.errors == ["No gene(s) found given NC_000001.200 on position 154191901"]
 
     # Invalid coordinates
     resp = await test_egc_mapper.genomic_to_tx_segment(


### PR DESCRIPTION
* Remove `uta_db.validate_genomic_ac` check in `_genomic_to_tx_segment`. `_get_genomic_ac_gene` already handles this check.