### PR TITLE
feat: update seqrepo and uta version to 20241220

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -40,7 +40,7 @@ Cool-Seq-Tool requires an available instance of the Universal Transcript Archive
    createuser -U postgres anonymous
    createdb -U postgres -O uta_admin uta
 
-   export UTA_VERSION=uta_20241220.pgd.gz  # most recent as of 2025/05/10
+   export UTA_VERSION=uta_20241220.pgd.gz  # most recent as of 2025/03/10
    curl -O https://dl.biocommons.org/uta/$UTA_VERSION
    gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -40,7 +40,7 @@ Cool-Seq-Tool requires an available instance of the Universal Transcript Archive
    createuser -U postgres anonymous
    createdb -U postgres -O uta_admin uta
 
-   export UTA_VERSION=uta_20241220.pgd.gz  # most recent as of 2023/12/05
+   export UTA_VERSION=uta_20241220.pgd.gz  # most recent as of 2025/05/10
    curl -O https://dl.biocommons.org/uta/$UTA_VERSION
    gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -69,7 +69,7 @@ While this should no longer occur with the latest SeqRepo release, some users in
 
 .. code-block::
 
-   PermissionError: [Error 13] Permission denied: '/usr/local/share/seqrepo/2024-12-20._fkuefgd' -> '/usr/local/share/seqrepo/2021-01-29'
+   PermissionError: [Error 13] Permission denied: '/usr/local/share/seqrepo/2024-12-20._fkuefgd' -> '/usr/local/share/seqrepo/2024-12-20'
 
 Try moving data manually with ``sudo``:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -40,11 +40,11 @@ Cool-Seq-Tool requires an available instance of the Universal Transcript Archive
    createuser -U postgres anonymous
    createdb -U postgres -O uta_admin uta
 
-   export UTA_VERSION=uta_20210129b.pgd.gz  # most recent as of 2023/12/05
+   export UTA_VERSION=uta_20241220.pgd.gz  # most recent as of 2023/12/05
    curl -O https://dl.biocommons.org/uta/$UTA_VERSION
    gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 
-By default, Cool-Seq-Tool expects to connect to the UTA database via a PostgreSQL connection served local on port 5432, under the PostgreSQL username ``uta_admin`` and the schema ``uta_20210129b``.
+By default, Cool-Seq-Tool expects to connect to the UTA database via a PostgreSQL connection served local on port 5432, under the PostgreSQL username ``uta_admin`` and the schema ``uta_20241220``.
 
 Set up SeqRepo
 --------------
@@ -56,20 +56,20 @@ Cool-Seq-Tool requires access to `SeqRepo <https://github.com/biocommons/biocomm
 .. code-block::
 
    pip install seqrepo
-   export SEQREPO_VERSION=2024-02-20
+   export SEQREPO_VERSION=2024-12-20
    sudo mkdir /usr/local/share/seqrepo
    sudo chown $USER /usr/local/share/seqrepo
    seqrepo pull -i $SEQREPO_VERSION
 
 .. note::
 
-   Our lab typically uses the latest SeqRepo release, which is ``2024-02-20`` as of this commit. To check for the presence of newer snapshots, use the ``seqrepo list-remote-instances`` CLI command.
+   Our lab typically uses the latest SeqRepo release, which is ``2024-12-20`` as of this commit. To check for the presence of newer snapshots, use the ``seqrepo list-remote-instances`` CLI command.
 
 While this should no longer occur with the latest SeqRepo release, some users in the past have reported experiencing the following error:
 
 .. code-block::
 
-   PermissionError: [Error 13] Permission denied: '/usr/local/share/seqrepo/2024-02-20._fkuefgd' -> '/usr/local/share/seqrepo/2021-01-29'
+   PermissionError: [Error 13] Permission denied: '/usr/local/share/seqrepo/2024-12-20._fkuefgd' -> '/usr/local/share/seqrepo/2021-01-29'
 
 Try moving data manually with ``sudo``:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -80,7 +80,7 @@ Individual classes will accept arguments upon initialization to set parameters r
    * - ``SEQREPO_ROOT_DIR``
      - Path to SeqRepo directory (i.e. contains ``aliases.sqlite3`` database file, and ``sequences`` directory). Used by :py:class:`SeqRepoAccess <cool_seq_tool.handlers.seqrepo_access.SeqRepoAccess>`. If not defined, defaults to ``/usr/local/share/seqrepo/latest``.
    * - ``UTA_DB_URL``
-     - A `libpq connection string <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_, i.e. of the form ``postgresql://<user>:<password>@<host>:<port>/<database>/<schema>``, used by the :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>` class. By default, it is set to ``postgresql://uta_admin:uta@localhost:5432/uta/uta_20210129b``.
+     - A `libpq connection string <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_, i.e. of the form ``postgresql://<user>:<password>@<host>:<port>/<database>/<schema>``, used by the :py:class:`UtaDatabase <cool_seq_tool.sources.uta_database.UtaDatabase>` class. By default, it is set to ``postgresql://uta_admin:uta@localhost:5432/uta/uta_20241220``.
    * - ``LIFTOVER_CHAIN_37_TO_38``
      - A path to a `chainfile <https://genome.ucsc.edu/goldenPath/help/chain.html>`_ for lifting from GRCh37 to GRCh38. Used by the :py:class:`LiftOver <cool_seq_tool.mappers.liftover.LiftOver>` class as input to `agct <https://pypi.org/project/agct/>`_. If not provided, agct will fetch it automatically from UCSC.
    * - ``LIFTOVER_CHAIN_38_TO_37``

--- a/src/cool_seq_tool/sources/uta_database.py
+++ b/src/cool_seq_tool/sources/uta_database.py
@@ -27,7 +27,7 @@ from cool_seq_tool.schemas import (
 UTADatabaseType = TypeVar("UTADatabaseType", bound="UtaDatabase")
 
 UTA_DB_URL = environ.get(
-    "UTA_DB_URL", "postgresql://uta_admin:uta@localhost:5432/uta/uta_20210129b"
+    "UTA_DB_URL", "postgresql://uta_admin:uta@localhost:5432/uta/uta_20241220"
 )
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
close #399

* Update default value for `UTA_DB_URL` to point to latest UTA version