### PR TITLE
chore: add vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ docs/source/reference/api
 
 # Files created by doctests
 tpm3.fasta
+
+# VSCode
+.vscode


### PR DESCRIPTION
Vscode creates files in `.vscode` when the project is opened. These should be ignored by version control.