### PR TITLE
fix: Redact auth from DB url in status check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "ga4gh.vrs >=2.1.3,<3.0",
     "wags-tails ~= 0.4.0",
     "bioutils",
-    "pip",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "ga4gh.vrs >=2.1.3,<3.0",
     "wags-tails ~= 0.4.0",
     "bioutils",
+    "pip",
 ]
 dynamic = ["version"]
 

--- a/src/cool_seq_tool/resources/status.py
+++ b/src/cool_seq_tool/resources/status.py
@@ -3,16 +3,16 @@
 import logging
 from collections import namedtuple
 from pathlib import Path
+from urllib.parse import urlparse
 
 from agct._core import ChainfileError
 from asyncpg import InvalidCatalogNameError, UndefinedTableError
 from biocommons.seqrepo import SeqRepo
-from pip._internal.utils.misc import redact_auth_from_url
 
 from cool_seq_tool.handlers.seqrepo_access import SEQREPO_ROOT_DIR, SeqRepoAccess
 from cool_seq_tool.mappers.liftover import LiftOver
 from cool_seq_tool.resources.data_files import DataFile, get_data_file
-from cool_seq_tool.sources.uta_database import UTA_DB_URL, UtaDatabase
+from cool_seq_tool.sources.uta_database import UTA_DB_URL, ParseResult, UtaDatabase
 
 _logger = logging.getLogger(__name__)
 
@@ -120,9 +120,12 @@ async def check_status(
     else:
         status["liftover"] = True
 
-    sanitized_url = redact_auth_from_url(UTA_DB_URL)
+    parsed_result = ParseResult(urlparse(db_url))
+    sanitized_url = parsed_result.sanitized_url
     try:
         await UtaDatabase.create(db_url)
+    except ValueError:
+        _logger.exception("Database URL is not valid")
     except (OSError, InvalidCatalogNameError, UndefinedTableError):
         _logger.exception(
             "Encountered error instantiating UTA at URI %s", sanitized_url

--- a/src/cool_seq_tool/resources/status.py
+++ b/src/cool_seq_tool/resources/status.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from agct._core import ChainfileError
 from asyncpg import InvalidCatalogNameError, UndefinedTableError
 from biocommons.seqrepo import SeqRepo
+from pip._internal.utils.misc import redact_auth_from_url
 
 from cool_seq_tool.handlers.seqrepo_access import SEQREPO_ROOT_DIR, SeqRepoAccess
 from cool_seq_tool.mappers.liftover import LiftOver
@@ -119,14 +120,17 @@ async def check_status(
     else:
         status["liftover"] = True
 
+    sanitized_url = redact_auth_from_url(UTA_DB_URL)
     try:
         await UtaDatabase.create(db_url)
     except (OSError, InvalidCatalogNameError, UndefinedTableError):
-        _logger.exception("Encountered error instantiating UTA at URI %s", UTA_DB_URL)
+        _logger.exception(
+            "Encountered error instantiating UTA at URI %s", sanitized_url
+        )
     except Exception as e:
         _logger.critical(
             "Encountered unexpected error instantiating UTA from URI %s: %s",
-            UTA_DB_URL,
+            sanitized_url,
             e,
         )
     else:

--- a/src/cool_seq_tool/sources/uta_database.py
+++ b/src/cool_seq_tool/sources/uta_database.py
@@ -5,7 +5,7 @@ import logging
 from os import environ
 from typing import Any, Literal, TypeVar
 from urllib.parse import ParseResult as UrlLibParseResult
-from urllib.parse import quote, unquote, urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 import asyncpg
 import boto3

--- a/src/cool_seq_tool/sources/uta_database.py
+++ b/src/cool_seq_tool/sources/uta_database.py
@@ -5,7 +5,7 @@ import logging
 from os import environ
 from typing import Any, Literal, TypeVar
 from urllib.parse import ParseResult as UrlLibParseResult
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 import asyncpg
 import boto3
@@ -954,3 +954,28 @@ class ParseResult(UrlLibParseResult):
         """Create schema property."""
         path_elems = self.path.split("/")
         return path_elems[2] if len(path_elems) > 2 else None
+
+    @property
+    def sanitized_url(self) -> str:
+        """Sanitized DB URL with the password masked"""
+        netloc = ""
+        if self.username:
+            netloc += self.username
+            if self.password is not None and self.password != "":
+                netloc += ":***"
+            netloc += "@"
+        if self.hostname:
+            netloc += f"{self.hostname}"
+        if self.port:
+            netloc += f":{self.port}"
+
+        return urlunparse(
+            (
+                self.scheme,
+                netloc,
+                self.path,
+                self.params,
+                self.query,
+                self.fragment,
+            )
+        )


### PR DESCRIPTION
At present, the status check logs the DB URL, including the password.

This PR uses a helper function from pip to redact the password from the URLs, making them safe to log.

After this change, this is what the log messages look like:
```
ERROR:cool_seq_tool.resources.status:Encountered error instantiating UTA at URI postgresql://uta_admin:****@localhost:5432/uta/uta_20241220
```

Closes #429 