### PR TITLE
fix: don't quote an already quoted url field

### DIFF
--- a/src/cool_seq_tool/sources/uta_database.py
+++ b/src/cool_seq_tool/sources/uta_database.py
@@ -5,7 +5,7 @@ import logging
 from os import environ
 from typing import Any, Literal, TypeVar
 from urllib.parse import ParseResult as UrlLibParseResult
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import unquote, urlparse
 
 import asyncpg
 import boto3
@@ -101,8 +101,7 @@ class UtaDatabase:
         """
         self.schema = None
         self._connection_pool = None
-        original_pwd = db_url.split("//")[-1].split("@")[0].split(":")[-1]
-        self.db_url = db_url.replace(original_pwd, quote(original_pwd))
+        self.db_url = db_url
         self.args = self._get_conn_args()
 
     def _get_conn_args(self) -> DbConnectionArgs:


### PR DESCRIPTION
At present, CST doesn't connect to UTA databases correctly if the password has special characters.

The database URL includes a password field, which is already embedded within a valid URL. The value was url quoted when the URL was generated, so it doesn't need to be quoted a second time when the URL is consumed by the UTA database code.

I tested this using a password `local@$%dev` and it attempted to authenticate with the password `local%40%24%25dev`. After this PR, it correctly uses the single-unquoted value.